### PR TITLE
Fix crash when ssl parameter of api is used

### DIFF
--- a/changelogs/fragments/3-api-ssl.yml
+++ b/changelogs/fragments/3-api-ssl.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "api - fix crash when the ``ssl`` parameter is used (https://github.com/ansible-collections/community.routeros/pull/3)."

--- a/plugins/modules/api.py
+++ b/plugins/modules/api.py
@@ -437,15 +437,15 @@ class ROS_api_module:
         self.result['message'].append("%s" % e)
         self.return_result(False, False)
 
-    def ros_api_connect(self, username, password, host, port, ssl):
+    def ros_api_connect(self, username, password, host, port, use_ssl):
         # connect to routeros api
         conn_status = {"connection": {"username": username,
                                       "hostname": host,
                                       "port": port,
-                                      "ssl": ssl,
+                                      "ssl": use_ssl,
                                       "status": "Connected"}}
         try:
-            if ssl is True:
+            if use_ssl is True:
                 if not port:
                     port = 8729
                     conn_status["connection"]["port"] = port


### PR DESCRIPTION
##### SUMMARY
The problem is that the function parameter is called `ssl`, which hides the `ssl` module which is also used in that function. This results in `error: 'bool' object has no attribute 'create_default_context'`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
api
