### PR TITLE
Allow `/` in hostnames/identity strings in terminal prompt parsing

### DIFF
--- a/changelogs/fragments/community.network-138-routeros-allow-slash.yml
+++ b/changelogs/fragments/community.network-138-routeros-allow-slash.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "routeros terminal plugin - allow slashes in hostnames for terminal detection. Without this, slashes in hostnames will result in connection timeouts (https://github.com/ansible-collections/community.network/pull/138)."

--- a/plugins/terminal/routeros.py
+++ b/plugins/terminal/routeros.py
@@ -47,7 +47,7 @@ class TerminalModule(TerminalBase):
 
     terminal_stdout_re = [
         re.compile(br"\x1b<"),
-        re.compile(br"\[[\w\.]+\@[\w\s\-\.]+\] ?> ?$"),
+        re.compile(br"\[[\w\.]+\@[\w\s\-\.\/]+\] ?> ?$"),
         re.compile(br"Please press \"Enter\" to continue!"),
         re.compile(br"Do you want to see the software license\? \[Y\/n\]: ?"),
     ]


### PR DESCRIPTION
Backport of ansible-collections/community.network#138.