### PR TITLE
Add preliminary documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 Provides modules for [Ansible](https://www.ansible.com/community) to manage [MikroTik RouterOS](http://www.mikrotik-routeros.net/routeros.aspx) instances.
 
+You can find [documentation for the modules and plugins in this collection here](https://ansible.fontein.de/collections/community/routeros/).
+
 ## Tested with Ansible
 
 Tested with both the current Ansible 2.9 and 2.10 releases and the current development version of Ansible. Ansible versions before 2.9.10 are not supported.
@@ -20,6 +22,8 @@ The collection supports the `network_cli` connection.
 - `community.routeros.api`
 - `community.routeros.command`
 - `community.routeros.facts`
+
+You can find [documentation for the modules and plugins in this collection here](https://ansible.fontein.de/collections/community/routeros/).
 
 ## Using this collection
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -16,6 +16,7 @@ tags:
 dependencies:
   ansible.netcommon: '>=1.0.0'
 repository: https://github.com/ansible-collections/community.routeros
+documentation: https://ansible.fontein.de/collections/community/routeros/
 #documentation: https://github.com/ansible-collection-migration/community.routeros/tree/main/docs
 homepage: https://github.com/ansible-collections/community.routeros
 issues: https://github.com/ansible-collections/community.routeros/issues


### PR DESCRIPTION
##### SUMMARY
The docs on the Ansible docsite will only appear once this collection is included in 2.10.x. This PR adds docs links to [my docsite](https://ansible.fontein.de/) which should be adjusted once the Ansible docsite contains community.routeros.

@heuels @NikolayDachev is this ok for you?

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
collection
