### PR TITLE
remove .id restriction for list_to_dic

### DIFF
--- a/changelogs/fragments/13-remove-id-restriction-for-api.yaml
+++ b/changelogs/fragments/13-remove-id-restriction-for-api.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- api - remove ``id to .id`` as default requirement which conflict with routeros ``id`` configuration parameter.  

--- a/changelogs/fragments/13-remove-id-restriction-for-api.yaml
+++ b/changelogs/fragments/13-remove-id-restriction-for-api.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-- api - remove ``id to .id`` as default requirement which conflict with routeros ``id`` configuration parameter.  
+- api - remove ``id to .id`` as default requirement which conflicts with RouterOS ``id`` configuration parameter (https://github.com/ansible-collections/community.routeros/pull/15).

--- a/plugins/modules/api.py
+++ b/plugins/modules/api.py
@@ -324,8 +324,6 @@ class ROS_api_module:
             if '=' not in p:
                 self.errors("missing '=' after '%s'" % p)
             p = p.split('=')
-            if p[0] == 'id':
-                self.errors("'%s' must be '.id'" % p[0])
             if p[1]:
                 dict[p[0]] = p[1]
         return dict


### PR DESCRIPTION
##### SUMMARY
Remove .id restriction, we have separate checks already (where is needed)
Fixes #13

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME
community.routeros.api
