### PR TITLE
docs: add note about hostnames and nested commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ There are two approaches for using this collection. The `command` and `facts` mo
 
 ### Prerequisites
 
-This collection does not support arbitrary symbols in router's identity. If you are having trouble connecting to your device, please make sure that your MikroTik's identity contains only alphanumeric characters and dashes. Also, `routeros.command` module does not support nesting commands. Running the following command will produce an error.
+This collection does not support arbitrary symbols in router's identity. If you are having trouble connecting to your device, please make sure that your MikroTik's identity contains only alphanumeric characters and dashes. Also, `routeros.command` module does not support nesting commands and expects every command to start with a forward slash (`/`). Running the following command will produce an error.
 
 ```yaml
 - community.routeros.command:

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ There are two approaches for using this collection. The `command` and `facts` mo
 
 ### Prerequisites
 
-This collection does not support arbitrary symbols in router's identity. If you are having trouble connecting to your device, please make sure that your MikroTik's identity contains only alphanumeric characters and dashes. Also, `routeros.command` module does not support nesting commands and expects every command to start with a forward slash (`/`). Running the following command will produce an error.
+The terminal-based modules in this collection (`community.routeros.command` and `community.routeros.facts`) do not support arbitrary symbols in router's identity. If you are having trouble connecting to your device, please make sure that your MikroTik's identity contains only alphanumeric characters and dashes. Also, the `community.routeros.command` module does not support nesting commands and expects every command to start with a forward slash (`/`). Running the following command will produce an error.
 
 ```yaml
 - community.routeros.command:

--- a/README.md
+++ b/README.md
@@ -31,6 +31,17 @@ See [Ansible Using collections](https://docs.ansible.com/ansible/latest/user_gui
 
 There are two approaches for using this collection. The `command` and `facts` modules use the `network_cli` connection and connect with SSH. The `api` module connects with the HTTP/HTTPS API.
 
+### Prerequisites
+
+This collection does not support arbitrary symbols in router's identity. If you are having trouble connecting to your device, please make sure that your MikroTik's identity contains only alphanumeric characters and dashes. Also, `routeros.command` module does not support nesting commands. Running the following command will produce an error.
+
+```yaml
+- community.routeros.command:
+    commands:
+      - /ip
+      - print
+```
+
 ### Connecting with `network_cli`
 
 Example inventory `hosts` file:


### PR DESCRIPTION
##### SUMMARY
This PR adds a note to README about router identity name conventions that should be followed, and a note about nested commands being unsupported.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
—

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

