### PR TITLE
filter out datetime from facts config

### DIFF
--- a/plugins/modules/facts.py
+++ b/plugins/modules/facts.py
@@ -285,6 +285,11 @@ class Config(FactsBase):
     def populate(self):
         super(Config, self).populate()
         data = self.responses[0]
+
+        # remove datetime
+        data = re.sub(
+            r'^# [a-z0-9/][a-z0-9/]* [0-9:]* by RouterOS', r'# RouterOS', data
+        )
         if data:
             self.facts['config'] = data
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Every time 'community.routeros.facts' subset 'config' returns data it's status is 'not changed' in persptective of device it is OK, but ...
Returned data are different on every run of 'community.routeros.facts' even configuration on device is not changed

Fixes #20 part 1.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
'community.routeros.facts' subset 'config'

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```BEFORE
# mar/22/2021 18:23:30 by RouterOS 6.40.3
# software id = 2TZZ-SFZA
#
# model = RouterBOARD 750G r3
# serial number = 6F3806FD9931
/interface ethernet
set [ find default-name=ether1 ] advertise=\
    10M-half,10M-full,100M-half,100M-full,1000M-half,1000M-full arp=enabled \
```
```AFTER
# RouterOS 6.40.3
# software id = 2TZZ-SFZA
#
# model = RouterBOARD 750G r3
# serial number = 6F3806FD9931
/interface ethernet
set [ find default-name=ether1 ] advertise=\
    10M-half,10M-full,100M-half,100M-full,1000M-half,1000M-full arp=enabled \

```
