### PR TITLE
Verbose config option

### DIFF
--- a/changelogs/fragments/1.2.0.yml
+++ b/changelogs/fragments/1.2.0.yml
@@ -1,1 +1,0 @@
-release_summary: This release allow nonverbose idempotent config in facts

--- a/changelogs/fragments/1.2.0.yml
+++ b/changelogs/fragments/1.2.0.yml
@@ -1,0 +1,1 @@
+release_summary: This release allow nonverbose idempotent config in facts

--- a/changelogs/fragments/22-idempotent_config.yml
+++ b/changelogs/fragments/22-idempotent_config.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - fact - add option _verbose_config_ to subset _config_ to turn off config verbosity (https://github.com/ansible-collections/community.routeros/pull/22)

--- a/changelogs/fragments/22-idempotent_config.yml
+++ b/changelogs/fragments/22-idempotent_config.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - fact - add option _verbose_config_ to subset _config_ to turn off config verbosity (https://github.com/ansible-collections/community.routeros/pull/22)
+  - fact - add option ``verbose_config`` to subset ``config`` to turn off config verbosity (https://github.com/ansible-collections/community.routeros/pull/22).

--- a/plugins/modules/facts.py
+++ b/plugins/modules/facts.py
@@ -29,9 +29,10 @@ options:
     default: '!config'
   verbose_config:
     description:
-      - When set C(false), config data will contain nonverbose config
+      - When set C(false), config data will contain nonverbose config.
     required: false
     default: true
+    version_added: 1.2.0
 '''
 
 EXAMPLES = """
@@ -584,7 +585,7 @@ def main():
     """
     argument_spec = dict(
         gather_subset=dict(default=['!config'], type='list'),
-        verbose_config=dict(default=True, type='bool')
+        verbose_config=dict(default=True, type='bool'),
     )
 
     argument_spec.update(routeros_argument_spec)

--- a/plugins/modules/facts.py
+++ b/plugins/modules/facts.py
@@ -588,7 +588,7 @@ def main():
     )
 
     argument_spec.update(routeros_argument_spec)
-    
+
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True)
 

--- a/plugins/modules/facts.py
+++ b/plugins/modules/facts.py
@@ -588,7 +588,7 @@ def main():
     )
 
     argument_spec.update(routeros_argument_spec)
-
+    
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True)
 

--- a/plugins/modules/facts.py
+++ b/plugins/modules/facts.py
@@ -291,23 +291,21 @@ class Hardware(FactsBase):
 
 class Config(FactsBase):
 
-    COMMANDS = [ '/export verbose' ]
-    COMMANDS_NO_VERBOSE = [ '/export' ]
+    COMMANDS = ['/export verbose']
+    COMMANDS_NO_VERBOSE = ['/export']
 
     RM_DATE_RE = re.compile(r'^# [a-z0-9/][a-z0-9/]* [0-9:]* by RouterOS')
-    def __init__(self, module):
-        self._module = module
-
-        if self._module.params['verbose_config'] == False :
-            self.COMMANDS = self.COMMANDS_NO_VERBOSE
 
     def populate(self):
+        if not self.module.params['verbose_config']:
+            self.COMMANDS = self.COMMANDS_NO_VERBOSE
+
         super(Config, self).populate()
         data = self.responses[0]
 
-        if self._module.params['verbose_config'] == False :        
+        if not self.module.params['verbose_config']:
             # remove datetime
-            data = re.sub(RM_DATE_RE, r'# RouterOS', data)
+            data = re.sub(self.RM_DATE_RE, r'# RouterOS', data)
 
         if data:
             self.facts['config'] = data
@@ -585,7 +583,7 @@ def main():
     """main entry point for module execution
     """
     argument_spec = dict(
-        gather_subset=dict(default=['!config'], type='list')
+        gather_subset=dict(default=['!config'], type='list'),
         verbose_config=dict(default=True, type='bool')
     )
 

--- a/tests/unit/plugins/modules/fixtures/facts/export
+++ b/tests/unit/plugins/modules/fixtures/facts/export
@@ -1,0 +1,26 @@
+# sep/25/2018 10:10:52 by RouterOS 6.42.5
+# software id = 9EER-511K
+#
+#
+#
+/interface wireless security-profiles
+set [ find default=yes ] supplicant-identity=MikroTik
+/tool user-manager customer
+set admin access=own-routers,own-users,own-profiles,own-limits,config-payment-gw
+/ip address
+add address=192.168.88.1/24 comment=defconf interface=ether1 network=192.168.88.0
+/ip dhcp-client
+add dhcp-options=hostname,clientid disabled=no interface=ether1
+/system lcd
+set contrast=0 enabled=no port=parallel type=24x4
+/system lcd page
+set time disabled=yes display-time=5s
+set resources disabled=yes display-time=5s
+set uptime disabled=yes display-time=5s
+set packets disabled=yes display-time=5s
+set bits disabled=yes display-time=5s
+set version disabled=yes display-time=5s
+set identity disabled=yes display-time=5s
+set ether1 disabled=yes display-time=5s
+/tool user-manager database
+set db-path=user-manager

--- a/tests/unit/plugins/modules/test_facts.py
+++ b/tests/unit/plugins/modules/test_facts.py
@@ -94,6 +94,13 @@ class TestRouterosFactsModule(TestRouterosModule):
             result['ansible_facts']['ansible_net_config'], str
         )
 
+    def test_facts_config_nonverbose(self):
+        set_module_args(dict(gather_subset='config', verbose_config=False))
+        result = self.execute_module()
+        self.assertIsInstance(
+            result['ansible_facts']['ansible_net_config'], str
+        )
+
     def test_facts_interfaces(self):
         set_module_args(dict(gather_subset='interfaces'))
         result = self.execute_module()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Every time 'community.routeros.facts' subset 'config' returns data it's status is 'not changed' in persptective of device it is OK, but ...
Returned data are different on every run of 'community.routeros.facts' even configuration on device is not changed

This adds facts option _verbose_config_ defaulting to _true_ to keep current operation
Setting to _false_ it makes _ansible_net_config_ indepotent (not changing on every _community.routeros.facts_ execution).

Fixes #20 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
'community.routeros.facts' subset 'config'

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->


