### PR TITLE
Disable use of deprecated Ciphers

### DIFF
--- a/changelogs/fragments/34-api-ciphers.yml
+++ b/changelogs/fragments/34-api-ciphers.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "api - when using TLS/SSL, remove explicit cipher configuration to insecure values, which also makes it impossible to connect to newer RouterOS versions (https://github.com/ansible-collections/community.routeros/pull/34)."

--- a/plugins/modules/api.py
+++ b/plugins/modules/api.py
@@ -451,7 +451,6 @@ class ROS_api_module:
                     conn_status["connection"]["port"] = port
                 ctx = ssl.create_default_context()
                 ctx.check_hostname = False
-                ctx.set_ciphers('ADH:@SECLEVEL=0')
                 api = connect(username=username,
                               password=password,
                               host=host,


### PR DESCRIPTION
##### SUMMARY
Old ciphers shouldn't be used. Devices that use newer ciphers couldn't be reached as the cipher was locked to sslv3.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
