### PR TITLE
Allow api module to fail

### DIFF
--- a/changelogs/fragments/39-api-fail.yml
+++ b/changelogs/fragments/39-api-fail.yml
@@ -1,6 +1,6 @@
-bugfixes:
+minor_changes:
 - >-
-  api - due to a programming error, the module never failed on errors.
+  api - due to a programming error, the module never failed on errors. This has now been fixed.
   If you are relying on the module not failing in case of idempotent commands
   (resulting in errors like ``failure: already have such address``), you need to adjust your roles/playbooks.
   We suggest to use ``failed_when`` to accept failure in specific circumstances,

--- a/changelogs/fragments/39-api-fail.yml
+++ b/changelogs/fragments/39-api-fail.yml
@@ -1,4 +1,4 @@
-minor_changes:
+breaking_changes:
 - >-
   api - due to a programming error, the module never failed on errors. This has now been fixed.
   If you are relying on the module not failing in case of idempotent commands

--- a/changelogs/fragments/39-api-fail.yml
+++ b/changelogs/fragments/39-api-fail.yml
@@ -1,2 +1,8 @@
 bugfixes:
-- "api - due to a programming error, the module never failed on errors (https://github.com/ansible-collections/community.routeros/pull/39)."
+- >-
+  api - due to a programming error, the module never failed on errors.
+  If you are relying on the module not failing in case of idempotent commands
+  (resulting in errors like ``failure: already have such address``), you need to adjust your roles/playbooks.
+  We suggest to use ``failed_when`` to accept failure in specific circumstances,
+  for example ``failed_when: "'failure: already have ' in result.msg[0]"``
+  (https://github.com/ansible-collections/community.routeros/pull/39).

--- a/changelogs/fragments/39-api-fail.yml
+++ b/changelogs/fragments/39-api-fail.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "api - due to a programming error, the module never failed on errors (https://github.com/ansible-collections/community.routeros/pull/39)."

--- a/plugins/modules/api.py
+++ b/plugins/modules/api.py
@@ -458,7 +458,7 @@ class ROS_api_module:
             self.errors(e)
 
     def return_result(self, ch_status=False, status=True):
-        if status == "False":
+        if not status:
             self.module.fail_json(msg=to_native(self.result['message']))
         else:
             self.module.exit_json(changed=ch_status,

--- a/plugins/modules/api.py
+++ b/plugins/modules/api.py
@@ -266,6 +266,7 @@ import traceback
 LIB_IMP_ERR = None
 try:
     from librouteros import connect
+    from librouteros.exceptions import LibRouterosError
     from librouteros.query import Key
     HAS_LIB = True
 except Exception as e:
@@ -373,7 +374,7 @@ class ROS_api_module:
             for i in self.api_path:
                 self.result['message'].append(i)
             self.return_result(False, True)
-        except Exception as e:
+        except LibRouterosError as e:
             self.errors(e)
 
     def api_add(self):
@@ -382,7 +383,7 @@ class ROS_api_module:
             self.result['message'].append("added: .id= %s"
                                           % self.api_path.add(**param))
             self.return_result(True)
-        except Exception as e:
+        except LibRouterosError as e:
             self.errors(e)
 
     def api_remove(self):
@@ -390,7 +391,7 @@ class ROS_api_module:
             self.api_path.remove(self.remove)
             self.result['message'].append("removed: .id= %s" % self.remove)
             self.return_result(True)
-        except Exception as e:
+        except LibRouterosError as e:
             self.errors(e)
 
     def api_update(self):
@@ -401,7 +402,7 @@ class ROS_api_module:
             self.api_path.update(**param)
             self.result['message'].append("updated: %s" % param)
             self.return_result(True)
-        except Exception as e:
+        except LibRouterosError as e:
             self.errors(e)
 
     def api_query(self):
@@ -440,7 +441,7 @@ class ROS_api_module:
                     msg = msg + ' WHERE %s' % ' '.join(self.where)
                 self.result['message'].append(msg)
             self.return_result(False)
-        except Exception as e:
+        except LibRouterosError as e:
             self.errors(e)
 
     def api_arbitrary(self):
@@ -454,7 +455,7 @@ class ROS_api_module:
             for i in arbitrary_result:
                 self.result['message'].append(i)
             self.return_result(False)
-        except Exception as e:
+        except LibRouterosError as e:
             self.errors(e)
 
     def return_result(self, ch_status=False, status=True):

--- a/plugins/modules/api.py
+++ b/plugins/modules/api.py
@@ -468,7 +468,7 @@ class ROS_api_module:
     def errors(self, e):
         if e.__class__.__name__ == 'TrapError':
             self.result['message'].append("%s" % e)
-            self.return_result(False, True)
+            self.return_result(False, False)
         self.result['message'].append("%s" % e)
         self.return_result(False, False)
 

--- a/plugins/modules/api.py
+++ b/plugins/modules/api.py
@@ -460,7 +460,7 @@ class ROS_api_module:
 
     def return_result(self, ch_status=False, status=True):
         if not status:
-            self.module.fail_json(msg=to_native(self.result['message']))
+            self.module.fail_json(msg=self.result['message'])
         else:
             self.module.exit_json(changed=ch_status,
                                   msg=self.result['message'])

--- a/tests/unit/plugins/modules/test_api.py
+++ b/tests/unit/plugins/modules/test_api.py
@@ -166,14 +166,15 @@ class TestRouterosApiModule(ModuleTestCase):
 
     @patch('ansible_collections.community.routeros.plugins.modules.api.ROS_api_module.api_add_path', new=fake_ros_api)
     def test_api_add_already_exist(self):
-        with self.assertRaises(AnsibleExitJson) as exc:
+        with self.assertRaises(AnsibleFailJson) as exc:
             module_args = self.config_module_args.copy()
             module_args['add'] = "name=unit_test_brige_exist"
             set_module_args(module_args)
             self.module.main()
 
         result = exc.exception.args[0]
-        self.assertEqual(result['changed'], False)
+        self.assertEqual(result['failed'], True)
+        self.assertEqual(result['msg'][0], 'failure: already have interface with such name')
 
     @patch('ansible_collections.community.routeros.plugins.modules.api.ROS_api_module.api_add_path', new=fake_ros_api)
     def test_api_remove(self):
@@ -188,14 +189,15 @@ class TestRouterosApiModule(ModuleTestCase):
 
     @patch('ansible_collections.community.routeros.plugins.modules.api.ROS_api_module.api_add_path', new=fake_ros_api)
     def test_api_remove_no_id(self):
-        with self.assertRaises(AnsibleExitJson) as exc:
+        with self.assertRaises(AnsibleFailJson) as exc:
             module_args = self.config_module_args.copy()
             module_args['remove'] = "*A2"
             set_module_args(module_args)
             self.module.main()
 
         result = exc.exception.args[0]
-        self.assertEqual(result['changed'], False)
+        self.assertEqual(result['failed'], True)
+        self.assertEqual(result['msg'][0], 'no such item (4)')
 
     @patch('ansible_collections.community.routeros.plugins.modules.api.ROS_api_module.api_add_path', new=fake_ros_api.arbitrary)
     def test_api_cmd(self):
@@ -210,14 +212,15 @@ class TestRouterosApiModule(ModuleTestCase):
 
     @patch('ansible_collections.community.routeros.plugins.modules.api.ROS_api_module.api_add_path', new=fake_ros_api.arbitrary)
     def test_api_cmd_none_existing_cmd(self):
-        with self.assertRaises(AnsibleExitJson) as exc:
+        with self.assertRaises(AnsibleFailJson) as exc:
             module_args = self.config_module_args.copy()
             module_args['cmd'] = "add NONE_EXIST=unit_test_brige_arbitrary"
             set_module_args(module_args)
             self.module.main()
 
         result = exc.exception.args[0]
-        self.assertEqual(result['changed'], False)
+        self.assertEqual(result['failed'], True)
+        self.assertEqual(result['msg'][0], 'no such command')
 
     @patch('ansible_collections.community.routeros.plugins.modules.api.ROS_api_module.api_add_path', new=fake_ros_api)
     def test_api_update(self):
@@ -232,14 +235,15 @@ class TestRouterosApiModule(ModuleTestCase):
 
     @patch('ansible_collections.community.routeros.plugins.modules.api.ROS_api_module.api_add_path', new=fake_ros_api)
     def test_api_update_none_existing_id(self):
-        with self.assertRaises(AnsibleExitJson) as exc:
+        with self.assertRaises(AnsibleFailJson) as exc:
             module_args = self.config_module_args.copy()
             module_args['update'] = ".id=*A2 name=unit_test_brige"
             set_module_args(module_args)
             self.module.main()
 
         result = exc.exception.args[0]
-        self.assertEqual(result['changed'], False)
+        self.assertEqual(result['failed'], True)
+        self.assertEqual(result['msg'][0], 'no such item (4)')
 
     @patch('ansible_collections.community.routeros.plugins.modules.api.ROS_api_module.api_add_path', new=fake_ros_api)
     def test_api_query(self):

--- a/tests/unit/plugins/modules/test_api.py
+++ b/tests/unit/plugins/modules/test_api.py
@@ -137,108 +137,150 @@ class TestRouterosApiModule(ModuleTestCase):
                                    "path": "interface bridge"}
 
     def test_module_fail_when_required_args_missing(self):
-        with self.assertRaises(AnsibleFailJson):
+        with self.assertRaises(AnsibleFailJson) as exc:
             set_module_args({})
             self.module.main()
 
+        result = exc.exception.args[0]
+        self.assertEqual(result['failed'], True)
+
     @patch('ansible_collections.community.routeros.plugins.modules.api.ROS_api_module.api_add_path', new=fake_ros_api.path)
     def test_api_path(self):
-        with self.assertRaises(AnsibleExitJson):
+        with self.assertRaises(AnsibleExitJson) as exc:
             set_module_args(self.config_module_args.copy())
             self.module.main()
 
+        result = exc.exception.args[0]
+        self.assertEqual(result['changed'], False)
+
     @patch('ansible_collections.community.routeros.plugins.modules.api.ROS_api_module.api_add_path', new=fake_ros_api)
     def test_api_add(self):
-        with self.assertRaises(AnsibleExitJson):
+        with self.assertRaises(AnsibleExitJson) as exc:
             module_args = self.config_module_args.copy()
             module_args['add'] = "name=unit_test_brige"
             set_module_args(module_args)
             self.module.main()
 
+        result = exc.exception.args[0]
+        self.assertEqual(result['changed'], True)
+
     @patch('ansible_collections.community.routeros.plugins.modules.api.ROS_api_module.api_add_path', new=fake_ros_api)
     def test_api_add_already_exist(self):
-        with self.assertRaises(AnsibleExitJson):
+        with self.assertRaises(AnsibleExitJson) as exc:
             module_args = self.config_module_args.copy()
             module_args['add'] = "name=unit_test_brige_exist"
             set_module_args(module_args)
             self.module.main()
 
+        result = exc.exception.args[0]
+        self.assertEqual(result['changed'], False)
+
     @patch('ansible_collections.community.routeros.plugins.modules.api.ROS_api_module.api_add_path', new=fake_ros_api)
     def test_api_remove(self):
-        with self.assertRaises(AnsibleExitJson):
+        with self.assertRaises(AnsibleExitJson) as exc:
             module_args = self.config_module_args.copy()
             module_args['remove'] = "*A1"
             set_module_args(module_args)
             self.module.main()
 
+        result = exc.exception.args[0]
+        self.assertEqual(result['changed'], True)
+
     @patch('ansible_collections.community.routeros.plugins.modules.api.ROS_api_module.api_add_path', new=fake_ros_api)
     def test_api_remove_no_id(self):
-        with self.assertRaises(AnsibleExitJson):
+        with self.assertRaises(AnsibleExitJson) as exc:
             module_args = self.config_module_args.copy()
             module_args['remove'] = "*A2"
             set_module_args(module_args)
             self.module.main()
 
+        result = exc.exception.args[0]
+        self.assertEqual(result['changed'], False)
+
     @patch('ansible_collections.community.routeros.plugins.modules.api.ROS_api_module.api_add_path', new=fake_ros_api.arbitrary)
     def test_api_cmd(self):
-        with self.assertRaises(AnsibleExitJson):
+        with self.assertRaises(AnsibleExitJson) as exc:
             module_args = self.config_module_args.copy()
             module_args['cmd'] = "add name=unit_test_brige_arbitrary"
             set_module_args(module_args)
             self.module.main()
 
+        result = exc.exception.args[0]
+        self.assertEqual(result['changed'], False)
+
     @patch('ansible_collections.community.routeros.plugins.modules.api.ROS_api_module.api_add_path', new=fake_ros_api.arbitrary)
     def test_api_cmd_none_existing_cmd(self):
-        with self.assertRaises(AnsibleExitJson):
+        with self.assertRaises(AnsibleExitJson) as exc:
             module_args = self.config_module_args.copy()
             module_args['cmd'] = "add NONE_EXIST=unit_test_brige_arbitrary"
             set_module_args(module_args)
             self.module.main()
 
+        result = exc.exception.args[0]
+        self.assertEqual(result['changed'], False)
+
     @patch('ansible_collections.community.routeros.plugins.modules.api.ROS_api_module.api_add_path', new=fake_ros_api)
     def test_api_update(self):
-        with self.assertRaises(AnsibleExitJson):
+        with self.assertRaises(AnsibleExitJson) as exc:
             module_args = self.config_module_args.copy()
             module_args['update'] = ".id=*A1 name=unit_test_brige"
             set_module_args(module_args)
             self.module.main()
 
+        result = exc.exception.args[0]
+        self.assertEqual(result['changed'], True)
+
     @patch('ansible_collections.community.routeros.plugins.modules.api.ROS_api_module.api_add_path', new=fake_ros_api)
     def test_api_update_none_existing_id(self):
-        with self.assertRaises(AnsibleExitJson):
+        with self.assertRaises(AnsibleExitJson) as exc:
             module_args = self.config_module_args.copy()
             module_args['update'] = ".id=*A2 name=unit_test_brige"
             set_module_args(module_args)
             self.module.main()
 
+        result = exc.exception.args[0]
+        self.assertEqual(result['changed'], False)
+
     @patch('ansible_collections.community.routeros.plugins.modules.api.ROS_api_module.api_add_path', new=fake_ros_api)
     def test_api_query(self):
-        with self.assertRaises(AnsibleExitJson):
+        with self.assertRaises(AnsibleExitJson) as exc:
             module_args = self.config_module_args.copy()
             module_args['query'] = ".id name"
             set_module_args(module_args)
             self.module.main()
 
+        result = exc.exception.args[0]
+        self.assertEqual(result['changed'], False)
+
     @patch('ansible_collections.community.routeros.plugins.modules.api.ROS_api_module.api_add_path', new=fake_ros_api)
     def test_api_query_missing_key(self):
-        with self.assertRaises(AnsibleExitJson):
+        with self.assertRaises(AnsibleExitJson) as exc:
             module_args = self.config_module_args.copy()
             module_args['query'] = ".id other"
             set_module_args(module_args)
             self.module.main()
 
+        result = exc.exception.args[0]
+        self.assertEqual(result['changed'], False)
+
     @patch('ansible_collections.community.routeros.plugins.modules.api.ROS_api_module.api_add_path', new=fake_ros_api.select_where)
     def test_api_query_and_WHERE(self):
-        with self.assertRaises(AnsibleExitJson):
+        with self.assertRaises(AnsibleExitJson) as exc:
             module_args = self.config_module_args.copy()
             module_args['query'] = ".id name WHERE name == dummy_bridge_A2"
             set_module_args(module_args)
             self.module.main()
 
+        result = exc.exception.args[0]
+        self.assertEqual(result['changed'], False)
+
     @patch('ansible_collections.community.routeros.plugins.modules.api.ROS_api_module.api_add_path', new=fake_ros_api.select_where)
     def test_api_query_and_WHERE_no_cond(self):
-        with self.assertRaises(AnsibleExitJson):
+        with self.assertRaises(AnsibleExitJson) as exc:
             module_args = self.config_module_args.copy()
             module_args['query'] = ".id name WHERE name != dummy_bridge_A2"
             set_module_args(module_args)
             self.module.main()
+
+        result = exc.exception.args[0]
+        self.assertEqual(result['changed'], False)


### PR DESCRIPTION
##### SUMMARY
Right now, the module will not fail when `return_result` is called with `status=False`, since it looks for `status == 'False'` (string instead of boolean).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
api
