### PR TITLE
Adjust docs links to devel docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Provides modules for [Ansible](https://www.ansible.com/community) to manage [MikroTik RouterOS](http://www.mikrotik-routeros.net/routeros.aspx) instances.
 
-You can find [documentation for the modules and plugins in this collection here](https://ansible.fontein.de/collections/community/routeros/).
+You can find [documentation for the modules and plugins in this collection here](https://docs.ansible.com/ansible/devel/collections/community/routeros/).
 
 ## Tested with Ansible
 
@@ -27,7 +27,7 @@ Please note that `community.routeros.api` module does **not** support Windows ju
 - `community.routeros.command`
 - `community.routeros.facts`
 
-You can find [documentation for the modules and plugins in this collection here](https://ansible.fontein.de/collections/community/routeros/).
+You can find [documentation for the modules and plugins in this collection here](https://docs.ansible.com/ansible/devel/collections/community/routeros/).
 
 ## Using this collection
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -16,8 +16,7 @@ tags:
 dependencies:
   ansible.netcommon: '>=1.0.0'
 repository: https://github.com/ansible-collections/community.routeros
-documentation: https://ansible.fontein.de/collections/community/routeros/
-#documentation: https://github.com/ansible-collection-migration/community.routeros/tree/main/docs
+documentation: https://docs.ansible.com/ansible/devel/collections/community/routeros/
 homepage: https://github.com/ansible-collections/community.routeros
 issues: https://github.com/ansible-collections/community.routeros/issues
 build_ignore:


### PR DESCRIPTION
##### SUMMARY
The `devel` docs (https://docs.ansible.com/ansible/devel/collections/community/routeros/) are (usually) regenerated nightly and contain the latest releases of a collection. We should point to the devel docs as our main documentation location.

(It will also show the 2.0.0 docs if we release 2.0.0, even though the `latest` docs will stick to the latest release included in Ansible 4.x.y.)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
README.md
galaxy.yml
