### PR TITLE
api: improve split handling

### DIFF
--- a/changelogs/fragments/47-api-split.yml
+++ b/changelogs/fragments/47-api-split.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - "api - improve splitting of ``WHERE`` queries (https://github.com/ansible-collections/community.routeros/pull/47)."
+  - "api - when converting result lists to dictionaries, no longer removes second ``=`` and text following that if present (https://github.com/ansible-collections/community.routeros/pull/47)."

--- a/plugins/modules/api.py
+++ b/plugins/modules/api.py
@@ -321,12 +321,14 @@ class ROS_api_module:
         self.where = None
         self.query = self.module.params['query']
         if self.query:
-            if 'WHERE' in self.query:
-                split = self.query.split('WHERE')
-                self.query = self.list_remove_empty(split[0].split(' '))
-                self.where = self.list_remove_empty(split[1].split(' '))
-            else:
-                self.query = self.list_remove_empty(self.module.params['query'].split(' '))
+            self.query = self.list_remove_empty(self.query.split(' '))
+            try:
+                idx = self.query.index('WHERE')
+                self.where = self.query[idx + 1:]
+                self.query = self.query[:idx]
+            except ValueError:
+                # Raised when WHERE has not been found
+                pass
 
         self.result = dict(
             message=[])
@@ -358,7 +360,7 @@ class ROS_api_module:
         for p in ldict:
             if '=' not in p:
                 self.errors("missing '=' after '%s'" % p)
-            p = p.split('=')
+            p = p.split('=', 1)
             if p[1]:
                 dict[p[0]] = p[1]
         return dict


### PR DESCRIPTION
##### SUMMARY
While reviewing #45 I noticed that there are two `split()` calls which need a split limit.

I rewrote the one handling `WHERE` to work better with #45 (namely first do the splitting, then search for the token `WHERE` in the splitted list to avoid finding a `WHERE` in a quoted string), and added a limit to the other.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
api
