### PR TITLE
Fix sanity errors

### DIFF
--- a/changelogs/fragments/55-linting.yml
+++ b/changelogs/fragments/55-linting.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - "command - the ``commands`` and ``wait_for`` options now convert the list elements to strings (https://github.com/ansible-collections/community.routeros/pull/55)."
+  - "facts - the ``gather_subset`` option now converts the list elements to strings (https://github.com/ansible-collections/community.routeros/pull/55)."

--- a/plugins/modules/command.py
+++ b/plugins/modules/command.py
@@ -27,6 +27,8 @@ options:
         module is not returned until the condition is satisfied or
         the number of retries has expired.
     required: true
+    type: list
+    elements: str
   wait_for:
     description:
       - List of conditions to evaluate against the output of the
@@ -34,6 +36,8 @@ options:
         before moving forward. If the conditional is not true
         within the configured number of retries, the task fails.
         See examples.
+    type: list
+    elements: str
   match:
     description:
       - The I(match) argument is used in conjunction with the
@@ -44,6 +48,7 @@ options:
         satisfied.
     default: all
     choices: ['any', 'all']
+    type: str
   retries:
     description:
       - Specifies the number of retries a command should by tried
@@ -51,6 +56,7 @@ options:
         target device every retry and evaluated against the
         I(wait_for) conditions.
     default: 10
+    type: int
   interval:
     description:
       - Configures the interval in seconds to wait between retries
@@ -58,6 +64,7 @@ options:
         conditions, the interval indicates how long to wait before
         trying the command again.
     default: 1
+    type: int
 seealso:
   - ref: ansible_collections.community.routeros.docsite.ssh-guide
     description: How to connect to RouterOS devices with SSH
@@ -131,10 +138,10 @@ def main():
     """main entry point for module execution
     """
     argument_spec = dict(
-        commands=dict(type='list', required=True),
+        commands=dict(type='list', elements='str', required=True),
 
-        wait_for=dict(type='list'),
-        match=dict(default='all', choices=['all', 'any']),
+        wait_for=dict(type='list', elements='str'),
+        match=dict(type='str', default='all', choices=['all', 'any']),
 
         retries=dict(default=10, type='int'),
         interval=dict(default=1, type='int')

--- a/plugins/modules/facts.py
+++ b/plugins/modules/facts.py
@@ -27,6 +27,8 @@ options:
         not be collected.
     required: false
     default: '!config'
+    type: list
+    elements: str
 seealso:
   - ref: ansible_collections.community.routeros.docsite.ssh-guide
     description: How to connect to RouterOS devices with SSH
@@ -586,7 +588,7 @@ def main():
     """main entry point for module execution
     """
     argument_spec = dict(
-        gather_subset=dict(default=['!config'], type='list')
+        gather_subset=dict(default=['!config'], type='list', elements='str')
     )
 
     argument_spec.update(routeros_argument_spec)

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -1,5 +1,0 @@
-plugins/modules/command.py validate-modules:doc-missing-type
-plugins/modules/command.py validate-modules:parameter-list-no-elements
-plugins/modules/command.py validate-modules:parameter-type-not-in-doc
-plugins/modules/facts.py validate-modules:parameter-list-no-elements
-plugins/modules/facts.py validate-modules:parameter-type-not-in-doc

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -1,5 +1,0 @@
-plugins/modules/command.py validate-modules:doc-missing-type
-plugins/modules/command.py validate-modules:parameter-list-no-elements
-plugins/modules/command.py validate-modules:parameter-type-not-in-doc
-plugins/modules/facts.py validate-modules:parameter-list-no-elements
-plugins/modules/facts.py validate-modules:parameter-type-not-in-doc

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -1,5 +1,0 @@
-plugins/modules/command.py validate-modules:doc-missing-type
-plugins/modules/command.py validate-modules:parameter-list-no-elements
-plugins/modules/command.py validate-modules:parameter-type-not-in-doc
-plugins/modules/facts.py validate-modules:parameter-list-no-elements
-plugins/modules/facts.py validate-modules:parameter-type-not-in-doc

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -1,5 +1,0 @@
-plugins/modules/command.py validate-modules:doc-missing-type
-plugins/modules/command.py validate-modules:parameter-list-no-elements
-plugins/modules/command.py validate-modules:parameter-type-not-in-doc
-plugins/modules/facts.py validate-modules:parameter-list-no-elements
-plugins/modules/facts.py validate-modules:parameter-type-not-in-doc

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -1,3 +1,0 @@
-plugins/modules/command.py validate-modules:doc-missing-type
-plugins/modules/command.py validate-modules:parameter-type-not-in-doc
-plugins/modules/facts.py validate-modules:parameter-type-not-in-doc


### PR DESCRIPTION
##### SUMMARY
So far we were ignoring several sanity errors. Let's fix them instead :)

For the list options, adding `elements='str'` makes AnsibleModule convert list elements to strings. This is a behavior change, that's why this is a feature and not just a bugfix or docs PR (though I guess if you passed something else before, it would have crashed the module or resulted in other errors :) ).

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
command
facts
