### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -85,6 +85,13 @@ jobs:
         with:
           path: ansible_collections/community/routeros
 
+      - name: Overwrite unit test requirements (if applicable)
+        run: |
+          if [ -e tests/unit/requirements-${{ matrix.ansible }}.txt ]; then
+            cp tests/unit/requirements-${{ matrix.ansible }}.txt tests/unit/requirements.txt
+          fi
+        working-directory: ./ansible_collections/community/routeros
+
       - name: Set up Python ${{ matrix.ansible }}
         uses: actions/setup-python@v2
         with:

--- a/tests/unit/requirements-stable-2.9.txt
+++ b/tests/unit/requirements-stable-2.9.txt
@@ -1,0 +1,4 @@
+unittest2 ; python_version <= '2.6'
+
+# requirements for api module
+librouteros < 3.2.0 ; python_version >= '3.6'


### PR DESCRIPTION
##### SUMMARY
Nightly CI fails with the latest librouteros 3.2.0 release: https://github.com/ansible-collections/community.routeros/runs/4224425595?check_suite_focus=true#step:6:457

This PR restricts the librouteros version for Ansible 2.9.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
