### PR TITLE
update community.routeros.api query functionality 

### DIFF
--- a/changelogs/fragments/63-add-extended_query.yml
+++ b/changelogs/fragments/63-add-extended_query.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - "extended_query - add new option ``extended query`` more complex queries against routeros api (https://github.com/ansible-collections/community.routeros/pull/63)."
+  - "query - update ``query`` to accept symbolic parameters (https://github.com/ansible-collections/community.routeros/pull/63)."

--- a/changelogs/fragments/63-add-extended_query.yml
+++ b/changelogs/fragments/63-add-extended_query.yml
@@ -1,3 +1,3 @@
 minor_changes:
-  - "extended_query - add new option ``extended query`` more complex queries against routeros api (https://github.com/ansible-collections/community.routeros/pull/63)."
+  - "api - add new option ``extended query`` more complex queries against RouterOS API (https://github.com/ansible-collections/community.routeros/pull/63)."
   - "query - update ``query`` to accept symbolic parameters (https://github.com/ansible-collections/community.routeros/pull/63)."

--- a/changelogs/fragments/63-add-extended_query.yml
+++ b/changelogs/fragments/63-add-extended_query.yml
@@ -1,3 +1,3 @@
 minor_changes:
   - "api - add new option ``extended query`` more complex queries against RouterOS API (https://github.com/ansible-collections/community.routeros/pull/63)."
-  - "query - update ``query`` to accept symbolic parameters (https://github.com/ansible-collections/community.routeros/pull/63)."
+  - "api - update ``query`` to accept symbolic parameters (https://github.com/ansible-collections/community.routeros/pull/63)."

--- a/plugins/modules/api.py
+++ b/plugins/modules/api.py
@@ -542,10 +542,6 @@ class ROS_api_module:
                 select = self.api_path.select(*self.extended_query['attributes'])
             for row in select:
                 self.result['message'].append(row)
-            if len(self.result['message']) < 1:
-                msg = "no results for '%s 'query' %s" % (' '.join(self.path),
-                                                         self.module.params['extended_query'])
-                self.result['message'].append(msg)
             self.return_result(False)
         except LibRouterosError as e:
             self.errors(e)

--- a/plugins/modules/api.py
+++ b/plugins/modules/api.py
@@ -52,7 +52,7 @@ options:
     description:
       - Query given path for selected query attributes from RouterOS aip.
       - WHERE is key word which extend query. WHERE format is key operator value - with spaces.
-      - WHERE valid operators are C(==) or C(is), C(!=) or C(not), C(>) or C(more), C(<) or C(less).
+      - WHERE valid operators are C(==) or C(eq), C(!=) or C(not), C(>) or C(more), C(<) or C(less).
       - Example path C(ip address) and query C(.id address) will return only C(.id) and C(address) for all items in C(ip address) path.
       - Example path C(ip address) and query C(.id address WHERE address == 1.1.1.3/32).
         will return only C(.id) and C(address) for items in C(ip address) path, where address is eq to 1.1.1.3/32.

--- a/plugins/modules/api.py
+++ b/plugins/modules/api.py
@@ -167,26 +167,26 @@ EXAMPLES = '''
         username: "{{ username }}"
         path: "ip address"
         extended_query:
-        attributes:
-          - network
-          - address
-          - .id
-        where:
-          - attribute: "network"
-            is: "=="
-            value: "192.168.255.0"
-          - or:
-              - attribute: "address"
-                is: "!="
-                value: "192.168.255.10/24"
-              - attribute: "address"
-                is: "eq"
-                value: "10.20.36.20/24"
-          - attribute: "network"
-            is: "in"
-            value:
-               - "10.20.36.0"
-               - "192.168.255.0"
+          attributes:
+            - network
+            - address
+            - .id
+          where:
+            - attribute: "network"
+              is: "=="
+              value: "192.168.255.0"
+            - or:
+                - attribute: "address"
+                  is: "!="
+                  value: "192.168.255.10/24"
+                - attribute: "address"
+                  is: "eq"
+                  value: "10.20.36.20/24"
+            - attribute: "network"
+              is: "in"
+              value:
+                 - "10.20.36.0"
+                 - "192.168.255.0"
 
     - name: Update example - ether2 ip addres with ".id = *14"
       community.routeros.api:

--- a/plugins/modules/api.py
+++ b/plugins/modules/api.py
@@ -256,16 +256,16 @@ class ROS_api_module:
                 where=dict(
                     type='list',
                     elements='dict',
-                    options=dict(
-                        attribute=dict(type='str'),
-                        is=dict(type='str', choices=["==", "!=", ">", "<", "in", "eq", "not", "more", "less"]),
-                        value=dict(type='raw'),
-                        or=dict(type='list', elements='dict', options=dict(
-                            attribute=dict(type='str', required=True),
-                            is=dict(type='str', choices=["==", "!=", ">", "<", "in", "eq", "not", "more", "less"], required=True),
-                            value=dict(type='raw', required=True),
-                        )),
-                    ),
+                    options={
+                        'attribute': dict(type='str'),
+                        'is': dict(type='str', choices=["==", "!=", ">", "<", "in", "eq", "not", "more", "less"]),
+                        'value': dict(type='raw'),
+                        'or': dict(type='list', elements='dict', options={
+                            'attribute': dict(type='str', required=True),
+                            'is': dict(type='str', choices=["==", "!=", ">", "<", "in", "eq", "not", "more", "less"], required=True),
+                            'value': dict(type='raw', required=True),
+                        }),
+                    },
                     required_together=[('attribute', 'is', 'value')],
                     mutually_exclusive=[('attribute', 'or')],
                     required_one_of=[('attribute', 'or')],

--- a/plugins/modules/api.py
+++ b/plugins/modules/api.py
@@ -252,8 +252,24 @@ class ROS_api_module:
             cmd=dict(type='str'),
             query=dict(type='str'),
             extended_query=dict(type='dict', options=dict(
-                attributes=dict(type='list', required=True),
-                where=dict(type='list')
+                attributes=dict(type='list', elements='str', required=True),
+                where=dict(
+                    type='list',
+                    elements='dict',
+                    options=dict(
+                        attribute=dict(type='str'),
+                        is=dict(type='str', choices=["==", "!=", ">", "<", "in", "eq", "not", "more", "less"]),
+                        value=dict(type='raw'),
+                        or=dict(type='list', elements='dict', options=dict(
+                            attribute=dict(type='str', required=True),
+                            is=dict(type='str', choices=["==", "!=", ">", "<", "in", "eq", "not", "more", "less"], required=True),
+                            value=dict(type='raw', required=True),
+                        )),
+                    ),
+                    required_together=[('attribute', 'is', 'value')],
+                    mutually_exclusive=[('attribute', 'or')],
+                    required_one_of=[('attribute', 'or')],
+                ),
 
             )),
         )

--- a/plugins/modules/api.py
+++ b/plugins/modules/api.py
@@ -330,37 +330,37 @@ class ROS_api_module:
         self.query_op_or = ["is", "not", "more", "less", "==", "!=", ">", "<"]
         if "items" not in self.extended_query.keys():
             self.errors("invalid 'query' syntax: missing 'items'")
-        if type(self.extended_query["items"]) is not list:
+        if not isinstance(self.extended_query["items"], list):
             self.errors("invalid 'query':'items' syntax: must be type list")
         if "id" in self.extended_query['items']:
             self.errors("invalid 'query':'items' syntax: 'id' must be '.id'")
         if "where" in self.extended_query.keys():
             check = "where"
-            if type(self.extended_query[check]) is not list:
+            if not isinstance(self.extended_query[check], list):
                 self.errors("invalid 'query':'%s' syntax: must be type list" % check)
             # we process nested list/dict structure
             # for key,valu,item variables folow the loops.
             # we start with 'w', for the next operation we add
             # 'k' for key, 'v' for value, 'i' for item - at the end of the new variable
             for w in self.extended_query[check]:
-                for wk,wv in w.items():
+                for wk, wv in w.items():
                     if wk not in self.extended_query["items"]:
                         self.errors("invalid 'query':'%s' syntax: '%s' not in 'items': '%s'"
                                     % (check, wk, self.extended_query["items"]))
-                    for wvk,wvv in wv.items():
+                    for wvk, wvv in wv.items():
                         if wvk not in self.query_op_all:
                             self.errors("invalid 'query':'%s' syntax: '%s' for '%s' is not a valid operator"
                                         % (check, wvk, w))
                         if wvk == "in":
-                            if type(wvv) is not list:
+                            if not isinstance(wvv, list):
                                 self.errors("invalid 'query':'%s':'%s':'%s' syntax: must be type list"
                                             % (check, wk, wvv))
                         if wvk == "or":
-                            if type(wvv) is not list:
+                            if not isinstance(wvv, list):
                                 self.errors("invalid 'query':'%s':'%s':'%s' syntax: must be type list"
                                             % (check, wk, wvv))
                             for wvvi in wvv:
-                                for wvvik,wvviv in wvvi.items():
+                                for wvvik, wvviv in wvvi.items():
                                     if wvvik not in self.query_op_or:
                                         self.errors("invalid 'query':'%s':'%s':'%s' '%s' is not a valid operator"
                                                     % (check, wk, wvk, wvvik))
@@ -454,15 +454,15 @@ class ROS_api_module:
     def build_api_extended_query(self, where_query, item, item_op, item_value):
         if item_op == 'is' or item_op == '==':
             return (self.query_keys[item] == item_value,)
-        elif item_op == 'not'or item_op == '!=':
+        elif item_op == 'not' or item_op == '!=':
             return (self.query_keys[item] != item_value,)
-        elif item_op == 'less'or item_op == '<':
+        elif item_op == 'less' or item_op == '<':
             return (self.query_keys[item] < item_value,)
         elif item_op == 'more' or item_op == '>':
             return (self.query_keys[item] > item_value,)
         else:
             self.errors("'%s' is not operator for '%s'"
-                        % (item_value,where_query))
+                        % (item_value, where_query))
 
     def api_extended_query(self):
         self.query_keys = {}
@@ -476,8 +476,8 @@ class ROS_api_module:
                 # we start with 'w', for the next operation we add
                 # 'k' for key, 'v' for value, 'i' for item - at the end of the new variable
                 for w in self.extended_query['where']:
-                    for wk,wv in w.items():
-                        for wvk,wvv in wv.items():
+                    for wk, wv in w.items():
+                        for wvk, wvv in wv.items():
                             # check 'in' items
                             if wvk == 'in':
                                 if where_args:
@@ -486,18 +486,18 @@ class ROS_api_module:
                                     where_args = (self.query_keys[wk].In(*wvv),)
                             # check 'or' items
                             elif wvk == 'or':
-                               where_or_args = False
-                               for wvvi in wvv:
-                                   for wvvik,wvviv in wvvi.items():
-                                       if where_or_args:
-                                           where_or_args = where_or_args \
-                                                           + self.build_api_extended_query(w, wk, wvvik, wvviv)
-                                       else:
-                                           where_or_args = self.build_api_extended_query(w, wk, wvvik, wvviv)
-                               if where_args:
-                                   where_args = where_args + (Or(*where_or_args),)
-                               else:
-                                   where_args = (Or(*where_or_args),)
+                                where_or_args = False
+                                for wvvi in wvv:
+                                    for wvvik, wvviv in wvvi.items():
+                                        if where_or_args:
+                                            where_or_args = where_or_args \
+                                                             + self.build_api_extended_query(w, wk, wvvik, wvviv)
+                                        else:
+                                            where_or_args = self.build_api_extended_query(w, wk, wvvik, wvviv)
+                                if where_args:
+                                    where_args = where_args + (Or(*where_or_args),)
+                                else:
+                                    where_args = (Or(*where_or_args),)
                             # check top itmes
                             else:
                                 if where_args:
@@ -512,7 +512,7 @@ class ROS_api_module:
                 self.result['message'].append(row)
             if len(self.result['message']) < 1:
                 msg = "no results for '%s 'query' %s" % (' '.join(self.path),
-                                                        self.module.params['extended_query'])
+                                                         self.module.params['extended_query'])
                 self.result['message'].append(msg)
             self.return_result(False)
         except LibRouterosError as e:

--- a/plugins/modules/api.py
+++ b/plugins/modules/api.py
@@ -345,20 +345,25 @@ class ROS_api_module:
             for w in self.extended_query[check]:
                 for wk,wv in w.items():
                     if wk not in self.extended_query["items"]:
-                        self.errors("invalid 'query':'%s' syntax: '%s' not in 'items': '%s'" % (check, wk, self.extended_query["items"]))
+                        self.errors("invalid 'query':'%s' syntax: '%s' not in 'items': '%s'"
+                                    % (check, wk, self.extended_query["items"]))
                     for wvk,wvv in wv.items():
                         if wvk not in self.query_op_all:
-                            self.errors("invalid 'query':'%s' syntax: '%s' for '%s' is not a valid operator" % (check, wvk, w))
+                            self.errors("invalid 'query':'%s' syntax: '%s' for '%s' is not a valid operator"
+                                        % (check, wvk, w))
                         if wvk == "in":
                             if type(wvv) is not list:
-                                self.errors("invalid 'query':'%s':'%s':'%s' syntax: must be type list" % (check, wk, wvv))
+                                self.errors("invalid 'query':'%s':'%s':'%s' syntax: must be type list"
+                                            % (check, wk, wvv))
                         if wvk == "or":
                             if type(wvv) is not list:
-                                self.errors("invalid 'query':'%s':'%s':'%s' syntax: must be type list" % (check, wk, wvv))
+                                self.errors("invalid 'query':'%s':'%s':'%s' syntax: must be type list"
+                                            % (check, wk, wvv))
                             for wvvi in wvv:
                                 for wvvik,wvviv in wvvi.items():
                                     if wvvik not in self.query_op_or:
-                                        self.errors("invalid 'query':'%s':'%s':'%s' '%s' is not a valid operator" % (check, wk, wvk, wvvik))
+                                        self.errors("invalid 'query':'%s':'%s':'%s' '%s' is not a valid operator"
+                                                    % (check, wk, wvk, wvvik))
 
     def list_to_dic(self, ldict):
         return convert_list_to_dictionary(ldict, skip_empty_values=True, require_assignment=True)
@@ -485,7 +490,8 @@ class ROS_api_module:
                                for wvvi in wvv:
                                    for wvvik,wvviv in wvvi.items():
                                        if where_or_args:
-                                           where_or_args = where_or_args + self.build_api_extended_query(w, wk, wvvik, wvviv)
+                                           where_or_args = where_or_args \
+                                                           + self.build_api_extended_query(w, wk, wvvik, wvviv)
                                        else:
                                            where_or_args = self.build_api_extended_query(w, wk, wvvik, wvviv)
                                if where_args:

--- a/plugins/modules/api.py
+++ b/plugins/modules/api.py
@@ -491,7 +491,7 @@ class ROS_api_module:
                                     for wvvik, wvviv in wvvi.items():
                                         if where_or_args:
                                             where_or_args = where_or_args \
-                                                             + self.build_api_extended_query(w, wk, wvvik, wvviv)
+                                                + self.build_api_extended_query(w, wk, wvvik, wvviv)
                                         else:
                                             where_or_args = self.build_api_extended_query(w, wk, wvvik, wvviv)
                                 if where_args:

--- a/plugins/modules/api.py
+++ b/plugins/modules/api.py
@@ -135,85 +135,103 @@ seealso:
 '''
 
 EXAMPLES = '''
----
-  tasks:
-    - name: Get example - ip address print
-      community.routeros.api:
-        hostname: "{{ hostname }}"
-        password: "{{ password }}"
-        username: "{{ username }}"
-        path: "ip address"
+- name: Get example - ip address print
+  community.routeros.api:
+    hostname: "{{ hostname }}"
+    password: "{{ password }}"
+    username: "{{ username }}"
+    path: "ip address"
+  register: ipaddrd_printout
 
-    - name: Add example - ip address
-      community.routeros.api:
-        hostname: "{{ hostname }}"
-        password: "{{ password }}"
-        username: "{{ username }}"
-        path: "ip address"
-        add: "address=192.168.255.10/24 interface=ether2"
+- name: Dump "Get example" output
+  ansible.builtin.debug:
+    msg: '{{ ipaddrd_printout }}'
 
-    - name: Query example - ".id, address" in "ip address WHERE address == 192.168.255.10/24"
-      community.routeros.api:
-        hostname: "{{ hostname }}"
-        password: "{{ password }}"
-        username: "{{ username }}"
-        path: "ip address"
-        query: ".id address WHERE address == {{ ip2 }}"
+- name: Add example - ip address
+  community.routeros.api:
+    hostname: "{{ hostname }}"
+    password: "{{ password }}"
+    username: "{{ username }}"
+    path: "ip address"
+    add: "address=192.168.255.10/24 interface=ether2"
 
-    - name: Extended query example - ".id,address,network" where address is not 192.168.255.10/24 or is 10.20.36.20/24
-      community.routeros.api:
-        hostname: "{{ hostname }}"
-        password: "{{ password }}"
-        username: "{{ username }}"
-        path: "ip address"
-        extended_query:
-          attributes:
-            - network
-            - address
-            - .id
-          where:
-            - attribute: "network"
-              is: "=="
-              value: "192.168.255.0"
-            - or:
-                - attribute: "address"
-                  is: "!="
-                  value: "192.168.255.10/24"
-                - attribute: "address"
-                  is: "eq"
-                  value: "10.20.36.20/24"
-            - attribute: "network"
-              is: "in"
-              value:
-                 - "10.20.36.0"
-                 - "192.168.255.0"
+- name: Query example - ".id, address" in "ip address WHERE address == 192.168.255.10/24"
+  community.routeros.api:
+    hostname: "{{ hostname }}"
+    password: "{{ password }}"
+    username: "{{ username }}"
+    path: "ip address"
+    query: ".id address WHERE address == {{ ip2 }}"
+  register: queryout
 
-    - name: Update example - ether2 ip addres with ".id = *14"
-      community.routeros.api:
-        hostname: "{{ hostname }}"
-        password: "{{ password }}"
-        username: "{{ username }}"
-        path: "ip address"
-        update: >-
-            .id=*14
-            address=192.168.255.20/24
-            comment={{ 'Update 192.168.255.10/24 with .id=*14 to 192.168.255.20/24 on ether2' | community.routeros.quote_argument_value }}
+- name: Dump "Query example" output
+  ansible.builtin.debug:
+    msg: '{{ queryout }}'
 
-    - name: Remove example - ether2 ip 192.168.255.20/24 with ".id = *14"
-      community.routeros.api:
-        hostname: "{{ hostname }}"
-        password: "{{ password }}"
-        username: "{{ username }}"
-        path: "ip address"
-        remove: "*14"
+- name: Extended query example - ".id,address,network" where address is not 192.168.255.10/24 or is 10.20.36.20/24
+  community.routeros.api:
+    hostname: "{{ hostname }}"
+    password: "{{ password }}"
+    username: "{{ username }}"
+    path: "ip address"
+    extended_query:
+      attributes:
+        - network
+        - address
+        - .id
+      where:
+        - attribute: "network"
+          is: "=="
+          value: "192.168.255.0"
+        - or:
+            - attribute: "address"
+              is: "!="
+              value: "192.168.255.10/24"
+            - attribute: "address"
+              is: "eq"
+              value: "10.20.36.20/24"
+        - attribute: "network"
+          is: "in"
+          value:
+             - "10.20.36.0"
+             - "192.168.255.0"
+  register: extended_queryout
 
-    - name: Arbitrary command example "/system identity print"
-      community.routeros.api:
-        hostname: "{{ hostname }}"
-        password: "{{ password }}"
-        username: "{{ username }}"
-        path: "system identity"
-        cmd: "print"
+- name: Dump "Extended query example" output
+  ansible.builtin.debug:
+    msg: '{{ extended_queryout }}'
+
+- name: Update example - ether2 ip addres with ".id = *14"
+  community.routeros.api:
+    hostname: "{{ hostname }}"
+    password: "{{ password }}"
+    username: "{{ username }}"
+    path: "ip address"
+    update: >-
+        .id=*14
+        address=192.168.255.20/24
+        comment={{ 'Update 192.168.255.10/24 to 192.168.255.20/24 on ether2' | community.routeros.quote_argument_value }}
+
+- name: Remove example - ether2 ip 192.168.255.20/24 with ".id = *14"
+  community.routeros.api:
+    hostname: "{{ hostname }}"
+    password: "{{ password }}"
+    username: "{{ username }}"
+    path: "ip address"
+    remove: "*14"
+
+- name: Arbitrary command example "/system identity print"
+  community.routeros.api:
+    hostname: "{{ hostname }}"
+    password: "{{ password }}"
+    username: "{{ username }}"
+    path: "system identity"
+    cmd: "print"
+  register: arbitraryout
+
+- name: Dump "Arbitrary command example" output
+  ansible.builtin.debug:
+    msg: '{{ arbitraryout }}'
 '''
 
 RETURN = '''

--- a/plugins/modules/api.py
+++ b/plugins/modules/api.py
@@ -346,31 +346,16 @@ class ROS_api_module:
             pass
 
     def check_extended_query_syntax(self, test_atr, or_msg=''):
-        extended_query_op = {'attribute': '', 'is': ["==", "!=", ">", "<", "in", "eq", "not", "more", "less"], 'value': ''}
-        if not isinstance(test_atr, dict):
-            self.errors("invalid syntax 'extended_query':'where':%s%s must be a type dict" % (or_msg, test_atr))
-        for ik in test_atr.keys():
-            if ik not in extended_query_op.keys():
-                self.errors("invalid syntax 'extended_query':'where'%s%s must have %s" % (or_msg, test_atr, extended_query_op.keys()))
-        if test_atr['is'] not in extended_query_op['is']:
-            self.errors("invalid syntax 'extended_query':'where':%s%s '%s' not a valid operator for 'is' %s" % (or_msg,
-                                                                                                                test_atr,
-                                                                                                                test_atr['is'],
-                                                                                                                extended_query_op['is']))
         if test_atr['is'] == "in" and not isinstance(test_atr['value'], list):
             self.errors("invalid syntax 'extended_query':'where':%s%s 'value' must be a type list" % (or_msg, test_atr))
 
     def check_extended_query(self):
         if self.extended_query["where"]:
             for i in self.extended_query['where']:
-                if "or" in i.keys():
-                    if not isinstance(i["or"], list):
-                        self.errors("invalid syntax 'extended_query':'where':'or':%s 'or' must be a type list" % i["or"])
+                if i["or"] is not None:
                     if len(i['or']) < 2:
                         self.errors("invalid syntax 'extended_query':'where':'or':%s 'or' requires minimum two items" % i["or"])
                     for orv in i['or']:
-                        if "or" in orv.keys():
-                            self.errors("invalid syntax 'extended_query':'where':'or':%s nested 'or' is not allowed" % i["or"])
                         self.check_extended_query_syntax(orv, ":'or':")
                 else:
                     self.check_extended_query_syntax(i)
@@ -463,21 +448,20 @@ class ROS_api_module:
 
     def build_api_extended_query(self, item):
         if item['attribute'] not in self.extended_query['attributes']:
-            self.errors("'%s' attribute is not in attributes:%s"
+            self.errors("'%s' attribute is not in attributes: %s"
                         % (item, self.extended_query['attributes']))
         if item['is'] == 'eq' or item['is'] == '==':
-            return (self.query_keys[item['attribute']] == item['value'],)
+            return self.query_keys[item['attribute']] == item['value']
         elif item['is'] == 'not' or item['is'] == '!=':
-            return (self.query_keys[item['attribute']] != item['value'],)
+            return self.query_keys[item['attribute']] != item['value']
         elif item['is'] == 'less' or item['is'] == '<':
-            return (self.query_keys[item['attribute']] < item['value'],)
+            return self.query_keys[item['attribute']] < item['value']
         elif item['is'] == 'more' or item['is'] == '>':
-            return (self.query_keys[item['attribute']] > item['value'],)
+            return self.query_keys[item['attribute']] > item['value']
         elif item['is'] == 'in':
-            return (self.query_keys[item['attribute']].In(*item['value']),)
+            return self.query_keys[item['attribute']].In(*item['value'])
         else:
-            self.errors("'%s' is not operator for 'is'"
-                        % item['is'])
+            self.errors("'%s' is not operator for 'is'" % item['is'])
 
     def api_extended_query(self):
         self.query_keys = {}
@@ -489,7 +473,7 @@ class ROS_api_module:
             if self.extended_query['where']:
                 where_args = []
                 for i in self.extended_query['where']:
-                    if "or" in i:
+                    if i['or']:
                         where_or_args = []
                         for ior in i['or']:
                             where_or_args.append(self.build_api_extended_query(ior))

--- a/plugins/modules/api.py
+++ b/plugins/modules/api.py
@@ -436,7 +436,7 @@ class ROS_api_module:
             keys[k] = Key(k)
         try:
             if self.where:
-                if self.where[1] == '==' or self.where[1] == 'eq':
+                if self.where[1] in ('==', 'eq'):
                     select = self.api_path.select(*keys).where(keys[self.where[0]] == self.where[2])
                 elif self.where[1] == '!=' or self.where[1] == 'not':
                     select = self.api_path.select(*keys).where(keys[self.where[0]] != self.where[2])
@@ -487,27 +487,18 @@ class ROS_api_module:
             self.query_keys[k] = Key(k)
         try:
             if self.extended_query['where']:
-                where_args = False
+                where_args = []
                 for i in self.extended_query['where']:
-                    if "or" in i.keys():
-                        where_or_args = False
+                    if "or" in i:
+                        where_or_args = []
                         for ior in i['or']:
-                            if where_or_args:
-                                where_or_args = where_or_args + self.build_api_extended_query(ior)
-                            else:
-                                where_or_args = self.build_api_extended_query(ior)
-                        if where_args:
-                            where_args = where_args + (Or(*where_or_args),)
-                        else:
-                            where_args = (Or(*where_or_args),)
+                            where_or_args.append(self.build_api_extended_query(ior))
+                        where_args.append(Or(*where_or_args))
                     else:
-                        if where_args:
-                            where_args = where_args + self.build_api_extended_query(i)
-                        else:
-                            where_args = self.build_api_extended_query(i)
+                        where_args.append(self.build_api_extended_query(i))
                 select = self.api_path.select(*self.query_keys).where(*where_args)
             else:
-                select = self.api_path.select(*self.query_keys)
+                select = self.api_path.select(*self.extended_query['attributes'])
             for row in select:
                 self.result['message'].append(row)
             if len(self.result['message']) < 1:

--- a/plugins/modules/api.py
+++ b/plugins/modules/api.py
@@ -151,7 +151,7 @@ EXAMPLES = '''
         username: "{{ username }}"
         path: "ip address"
         add: "address=192.168.255.10/24 interface=ether2"
-   
+
     - name: Query example - ".id, address" in "ip address WHERE address == 192.168.255.10/24"
       community.routeros.api:
         hostname: "{{ hostname }}"

--- a/tests/unit/plugins/modules/fake_api.py
+++ b/tests/unit/plugins/modules/fake_api.py
@@ -116,3 +116,12 @@ class Key(object):
 
     def str_return(self):
         return str(self.name)
+
+
+class Or(object):
+    def __init__(self, *args):
+        self.args = args
+        self.str_return()
+
+    def str_return(self):
+        return repr(self.args)

--- a/tests/unit/plugins/modules/fake_api.py
+++ b/tests/unit/plugins/modules/fake_api.py
@@ -90,7 +90,7 @@ class fake_ros_api(object):
         if result:
             return result
         else:
-            return ["no results for 'interface bridge 'query' %s" % ' '.join(args)]
+            return []
 
     @classmethod
     def select_where(cls, api, path):
@@ -106,7 +106,7 @@ class Where(object):
         return self
 
     def where(self, *args):
-        return ["*A1"]
+        return [{".id": "*A1", "name": "dummy_bridge_A1"}]
 
 
 class Key(object):

--- a/tests/unit/plugins/modules/test_api.py
+++ b/tests/unit/plugins/modules/test_api.py
@@ -197,3 +197,69 @@ class TestRouterosApiModule(ModuleTestCase):
 
         result = exc.exception.args[0]
         self.assertEqual(result['changed'], False)
+
+    @patch('ansible_collections.community.routeros.plugins.modules.api.ROS_api_module.api_add_path', new=fake_ros_api)
+    def test_api_extended_query(self):
+        with self.assertRaises(AnsibleExitJson) as exc:
+            module_args = self.config_module_args.copy()
+            module_args['extended_query'] = {
+                'attributes': ['.id', 'name'],
+            }
+            set_module_args(module_args)
+            self.module.main()
+
+        result = exc.exception.args[0]
+        self.assertEqual(result['changed'], False)
+
+    @patch('ansible_collections.community.routeros.plugins.modules.api.ROS_api_module.api_add_path', new=fake_ros_api)
+    def test_api_extended_query_missing_key(self):
+        with self.assertRaises(AnsibleExitJson) as exc:
+            module_args = self.config_module_args.copy()
+            module_args['extended_query'] = {
+                'attributes': ['.id', 'other'],
+            }
+            set_module_args(module_args)
+            self.module.main()
+
+        result = exc.exception.args[0]
+        self.assertEqual(result['changed'], False)
+
+    @patch('ansible_collections.community.routeros.plugins.modules.api.ROS_api_module.api_add_path', new=fake_ros_api.select_where)
+    def test_api_extended_query_and_WHERE(self):
+        with self.assertRaises(AnsibleExitJson) as exc:
+            module_args = self.config_module_args.copy()
+            module_args['extended_query'] = {
+                'attributes': ['.id', 'name'],
+                'where': [
+                    {
+                        'attribute': 'name',
+                        'is': '==',
+                        'value': 'dummy_bridge_A2',
+                    },
+                ],
+            }
+            set_module_args(module_args)
+            self.module.main()
+
+        result = exc.exception.args[0]
+        self.assertEqual(result['changed'], False)
+
+    @patch('ansible_collections.community.routeros.plugins.modules.api.ROS_api_module.api_add_path', new=fake_ros_api.select_where)
+    def test_api_extended_query_and_WHERE_no_cond(self):
+        with self.assertRaises(AnsibleExitJson) as exc:
+            module_args = self.config_module_args.copy()
+            module_args['extended_query'] = {
+                'attributes': ['.id', 'name'],
+                'where': [
+                    {
+                        'attribute': 'name',
+                        'is': 'not',
+                        'value': 'dummy_bridge_A2',
+                    },
+                ],
+            }
+            set_module_args(module_args)
+            self.module.main()
+
+        result = exc.exception.args[0]
+        self.assertEqual(result['changed'], False)

--- a/tests/unit/plugins/modules/test_api.py
+++ b/tests/unit/plugins/modules/test_api.py
@@ -164,6 +164,11 @@ class TestRouterosApiModule(ModuleTestCase):
 
         result = exc.exception.args[0]
         self.assertEqual(result['changed'], False)
+        self.assertEqual(result['msg'], [
+            {'.id': '*A1', 'name': 'dummy_bridge_A1'},
+            {'.id': '*A2', 'name': 'dummy_bridge_A2'},
+            {'.id': '*A3', 'name': 'dummy_bridge_A3'},
+        ])
 
     @patch('ansible_collections.community.routeros.plugins.modules.api.ROS_api_module.api_add_path', new=fake_ros_api)
     def test_api_query_missing_key(self):
@@ -175,6 +180,7 @@ class TestRouterosApiModule(ModuleTestCase):
 
         result = exc.exception.args[0]
         self.assertEqual(result['changed'], False)
+        self.assertEqual(result['msg'], ["no results for 'interface bridge 'query' .id other"])
 
     @patch('ansible_collections.community.routeros.plugins.modules.api.ROS_api_module.api_add_path', new=fake_ros_api.select_where)
     def test_api_query_and_WHERE(self):
@@ -186,6 +192,9 @@ class TestRouterosApiModule(ModuleTestCase):
 
         result = exc.exception.args[0]
         self.assertEqual(result['changed'], False)
+        self.assertEqual(result['msg'], [
+            {'.id': '*A1', 'name': 'dummy_bridge_A1'},
+        ])
 
     @patch('ansible_collections.community.routeros.plugins.modules.api.ROS_api_module.api_add_path', new=fake_ros_api.select_where)
     def test_api_query_and_WHERE_no_cond(self):
@@ -197,6 +206,9 @@ class TestRouterosApiModule(ModuleTestCase):
 
         result = exc.exception.args[0]
         self.assertEqual(result['changed'], False)
+        self.assertEqual(result['msg'], [
+            {'.id': '*A1', 'name': 'dummy_bridge_A1'},
+        ])
 
     @patch('ansible_collections.community.routeros.plugins.modules.api.ROS_api_module.api_add_path', new=fake_ros_api)
     def test_api_extended_query(self):
@@ -210,6 +222,11 @@ class TestRouterosApiModule(ModuleTestCase):
 
         result = exc.exception.args[0]
         self.assertEqual(result['changed'], False)
+        self.assertEqual(result['msg'], [
+            {'.id': '*A1', 'name': 'dummy_bridge_A1'},
+            {'.id': '*A2', 'name': 'dummy_bridge_A2'},
+            {'.id': '*A3', 'name': 'dummy_bridge_A3'},
+        ])
 
     @patch('ansible_collections.community.routeros.plugins.modules.api.ROS_api_module.api_add_path', new=fake_ros_api)
     def test_api_extended_query_missing_key(self):
@@ -223,6 +240,7 @@ class TestRouterosApiModule(ModuleTestCase):
 
         result = exc.exception.args[0]
         self.assertEqual(result['changed'], False)
+        self.assertEqual(result['msg'], [])
 
     @patch('ansible_collections.community.routeros.plugins.modules.api.ROS_api_module.api_add_path', new=fake_ros_api.select_where)
     def test_api_extended_query_and_WHERE(self):
@@ -243,6 +261,9 @@ class TestRouterosApiModule(ModuleTestCase):
 
         result = exc.exception.args[0]
         self.assertEqual(result['changed'], False)
+        self.assertEqual(result['msg'], [
+            {'.id': '*A1', 'name': 'dummy_bridge_A1'},
+        ])
 
     @patch('ansible_collections.community.routeros.plugins.modules.api.ROS_api_module.api_add_path', new=fake_ros_api.select_where)
     def test_api_extended_query_and_WHERE_no_cond(self):
@@ -263,3 +284,38 @@ class TestRouterosApiModule(ModuleTestCase):
 
         result = exc.exception.args[0]
         self.assertEqual(result['changed'], False)
+        self.assertEqual(result['msg'], [
+            {'.id': '*A1', 'name': 'dummy_bridge_A1'},
+        ])
+
+    @patch('ansible_collections.community.routeros.plugins.modules.api.ROS_api_module.api_add_path', new=fake_ros_api.select_where)
+    def test_api_extended_query_and_WHERE_or(self):
+        with self.assertRaises(AnsibleExitJson) as exc:
+            module_args = self.config_module_args.copy()
+            module_args['extended_query'] = {
+                'attributes': ['.id', 'name'],
+                'where': [
+                    {
+                        'or': [
+                            {
+                                'attribute': 'name',
+                                'is': 'in',
+                                'value': [1, 2],
+                            },
+                            {
+                                'attribute': 'name',
+                                'is': '!=',
+                                'value': 5,
+                            },
+                        ],
+                    },
+                ],
+            }
+            set_module_args(module_args)
+            self.module.main()
+
+        result = exc.exception.args[0]
+        self.assertEqual(result['changed'], False)
+        self.assertEqual(result['msg'], [
+            {'.id': '*A1', 'name': 'dummy_bridge_A1'},
+        ])

--- a/tests/unit/plugins/modules/test_api.py
+++ b/tests/unit/plugins/modules/test_api.py
@@ -21,7 +21,7 @@ import json
 import pytest
 
 from ansible_collections.community.routeros.tests.unit.compat.mock import patch, MagicMock
-from ansible_collections.community.routeros.tests.unit.plugins.modules.fake_api import FakeLibRouterosError, Key, fake_ros_api
+from ansible_collections.community.routeros.tests.unit.plugins.modules.fake_api import FakeLibRouterosError, Key, Or, fake_ros_api
 from ansible_collections.community.routeros.tests.unit.plugins.modules.utils import set_module_args, AnsibleExitJson, AnsibleFailJson, ModuleTestCase
 from ansible_collections.community.routeros.plugins.modules import api
 
@@ -37,6 +37,7 @@ class TestRouterosApiModule(ModuleTestCase):
         self.patch_create_api = patch('ansible_collections.community.routeros.plugins.modules.api.create_api', MagicMock(new=fake_ros_api))
         self.patch_create_api.start()
         self.module.Key = MagicMock(new=Key)
+        self.module.Or = MagicMock(new=Or)
         self.config_module_args = {"username": "admin",
                                    "password": "pаss",
                                    "hostname": "127.0.0.1",


### PR DESCRIPTION
##### SUMMARY
Right now community.routeros.api query - WHERE is limited to single criteria.
We should update it to use all librouteos functionality. Also this will help with routeros/ansible idempotent functionality.
For understandable reasons RouterOS allow to add multiple configs with same value (for some configurations), in result when we add something with API we are not able to do correct match if the required config already exist or not which will make duplicated config entries!.

For example 'add' task can be executed only if 'query' do not return .id for existing config which match multiple criteria. etc.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
community.routeros.api

##### ADDITIONAL INFORMATION
libouteros: https://github.com/luqasz/librouteros
librouteros docs: https://librouteros.readthedocs.io/en/latest/query.html#

What we missing is AND, OR for query-where 

Test playbook

```
- name: ros query example
  hosts: ros_testing
  gather_facts: no
  connection: local

  tasks:
  - name: query in {{ ros_query_path }} for {{ ros_query_for }}
    vars:
      ros_query_path: "{{ ros_testing_query_path }}"
      ros_query_for: "{{ ros_testing_query }}"
    community.routeros.api:
      hostname: "{{ ros_hostname }}"
      ssl: "{{ ros_ssl }}"
      password: "{{ ros_password }}"
      username: "{{ ros_username }}"
      path: "{{ ros_query_path }}"
      query: "{{ ros_query_for }}"
    register: rosquery
    delegate_to: localhost
```

RouterOS (CHR 7.2rc1) config
```
[admin@eve-mk1] > /ip/address/export 
# jan/12/2022 12:15:29 by RouterOS 7.2rc1
# software id = 
#
/ip address
add address=192.168.58.254/24 interface=ether2 network=192.168.58.0
add address=192.168.58.1/24 interface=ether2 network=192.168.58.0
add address=192.168.58.2/24 interface=ether2 network=192.168.58.0
```

Testing before change:

1. Whiout WHERE - get all
```
$ ansible-playbook playbooks/ros/testing/ros_query_devel.yml --ask-vault-pass -v -e ros_testing_query="'.id network address'"
Using /opt/gitea/ansible/ansible.cfg as config file
Vault password: 
[WARNING]: An error occurred while calling ansible.utils.display.initialize_locale (unsupported locale setting). This may result in incorrectly calculated text widths that can cause Display to print
incorrect line lengths

PLAY [ros query example] ***********************************************************************************************************************************************************************************

TASK [query in ip address for .id network address] *********************************************************************************************************************************************************
ok: [10.20.36.253 -> localhost] => {"changed": false, "msg": [{".id": "*1", "address": "10.20.36.253/24", "network": "10.20.36.0"}, {".id": "*3", "address": "192.168.58.254/24", "network": "192.168.58.0"}, {".id": "*4", "address": "192.168.58.1/24", "network": "192.168.58.0"}, {".id": "*5", "address": "192.168.58.2/24", "network": "192.168.58.0"}]}

PLAY RECAP *************************************************************************************************************************************************************************************************
10.20.36.253               : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```

2. WHERE with single criteria

```
$ ansible-playbook playbooks/ros/testing/ros_query_devel.yml --ask-vault-pass -v -e ros_testing_query="'.id network address WHERE network == 192.168.58.0'"
Using /opt/gitea/ansible/ansible.cfg as config file
Vault password: 
[WARNING]: An error occurred while calling ansible.utils.display.initialize_locale (unsupported locale setting). This may result in incorrectly calculated text widths that can cause Display to print
incorrect line lengths

PLAY [ros query example] ***********************************************************************************************************************************************************************************

TASK [query in ip address for .id network address WHERE network == 192.168.58.0] ***************************************************************************************************************************
ok: [10.20.36.253 -> localhost] => {"changed": false, "msg": [{".id": "*3", "address": "192.168.58.254/24", "network": "192.168.58.0"}, {".id": "*4", "address": "192.168.58.1/24", "network": "192.168.58.0"}, {".id": "*5", "address": "192.168.58.2/24", "network": "192.168.58.0"}]}

PLAY RECAP *************************************************************************************************************************************************************************************************
10.20.36.253               : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```

3. WHERE with multiple criterias (this we want to change)

```
$ ansible-playbook playbooks/ros/testing/ros_query_devel.yml --ask-vault-pass -v -e ros_testing_query="'.id network address WHERE network == 192.168.58.0, address != 192.168.58.254/24'"
Using /opt/gitea/ansible/ansible.cfg as config file
Vault password: 
[WARNING]: An error occurred while calling ansible.utils.display.initialize_locale (unsupported locale setting). This may result in incorrectly calculated text widths that can cause Display to print
incorrect line lengths

PLAY [ros query example] ***********************************************************************************************************************************************************************************

TASK [query in ip address for .id network address WHERE network == 192.168.58.0, address != 192.168.58.254/24] *********************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: AttributeError: 'ROS_api_module' object has no attribute 'result'
fatal: [10.20.36.253 -> localhost]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_community.routeros.api_payload_wgp1_1x6/ansible_community.routeros.api_payload.zip/ansible_collections/community/routeros/plugins/modules/api.py\", line 354, in __init__\n  File \"/tmp/ansible_community.routeros.api_payload_wgp1_1x6/ansible_community.routeros.api_payload.zip/ansible_collections/community/routeros/plugins/module_utils/quoting.py\", line 110, in parse_argument_value\nansible_collections.community.routeros.plugins.module_utils.quoting.ParseError: Unexpected data at end of value\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File \"/home/dako/.ansible/tmp/ansible-tmp-1641990267.2573767-3558077-34968152862448/AnsiballZ_api.py\", line 100, in <module>\n    _ansiballz_main()\n  File \"/home/dako/.ansible/tmp/ansible-tmp-1641990267.2573767-3558077-34968152862448/AnsiballZ_api.py\", line 92, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/home/dako/.ansible/tmp/ansible-tmp-1641990267.2573767-3558077-34968152862448/AnsiballZ_api.py\", line 40, in invoke_module\n    runpy.run_module(mod_name='ansible_collections.community.routeros.plugins.modules.api', init_globals=dict(_module_fqn='ansible_collections.community.routeros.plugins.modules.api', _modlib_path=modlib_path),\n  File \"/usr/lib/python3.9/runpy.py\", line 210, in run_module\n    return _run_module_code(code, init_globals, run_name, mod_spec)\n  File \"/usr/lib/python3.9/runpy.py\", line 97, in _run_module_code\n    _run_code(code, mod_globals, init_globals,\n  File \"/usr/lib/python3.9/runpy.py\", line 87, in _run_code\n    exec(code, run_globals)\n  File \"/tmp/ansible_community.routeros.api_payload_wgp1_1x6/ansible_community.routeros.api_payload.zip/ansible_collections/community/routeros/plugins/modules/api.py\", line 550, in <module>\n  File \"/tmp/ansible_community.routeros.api_payload_wgp1_1x6/ansible_community.routeros.api_payload.zip/ansible_collections/community/routeros/plugins/modules/api.py\", line 546, in main\n  File \"/tmp/ansible_community.routeros.api_payload_wgp1_1x6/ansible_community.routeros.api_payload.zip/ansible_collections/community/routeros/plugins/modules/api.py\", line 357, in __init__\n  File \"/tmp/ansible_community.routeros.api_payload_wgp1_1x6/ansible_community.routeros.api_payload.zip/ansible_collections/community/routeros/plugins/modules/api.py\", line 497, in errors\nAttributeError: 'ROS_api_module' object has no attribute 'result'\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}

PLAY RECAP *************************************************************************************************************************************************************************************************
10.20.36.253               : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0  
```

Testing with current change (not completed read more!):

1. Whiout WHERE - get all

```
$ ansible-playbook playbooks/ros/testing/ros_query_devel.yml --ask-vault-pass -v -e ros_testing_query="'.id network address'"
Using /opt/gitea/ansible/ansible.cfg as config file
Vault password: 
[WARNING]: An error occurred while calling ansible.utils.display.initialize_locale (unsupported locale setting). This may result in incorrectly calculated text widths that can cause Display to print
incorrect line lengths

PLAY [ros query example] ***********************************************************************************************************************************************************************************

TASK [query in ip address for .id network address] *********************************************************************************************************************************************************
ok: [10.20.36.253 -> localhost] => {"changed": false, "msg": [{".id": "*1", "address": "10.20.36.253/24", "network": "10.20.36.0"}, {".id": "*3", "address": "192.168.58.254/24", "network": "192.168.58.0"}, {".id": "*4", "address": "192.168.58.1/24", "network": "192.168.58.0"}, {".id": "*5", "address": "192.168.58.2/24", "network": "192.168.58.0"}]}

PLAY RECAP *************************************************************************************************************************************************************************************************
10.20.36.253               : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0  
```

2. WHERE with single criteria

```
$ ansible-playbook playbooks/ros/testing/ros_query_devel.yml --ask-vault-pass -v -e ros_testing_query="'.id network address WHERE network == 192.168.58.0'"
Using /opt/gitea/ansible/ansible.cfg as config file
Vault password: 
[WARNING]: An error occurred while calling ansible.utils.display.initialize_locale (unsupported locale setting). This may result in incorrectly calculated text widths that can cause Display to print
incorrect line lengths

PLAY [ros query example] ***********************************************************************************************************************************************************************************

TASK [query in ip address for .id network address WHERE network == 192.168.58.0] ***************************************************************************************************************************
ok: [10.20.36.253 -> localhost] => {"changed": false, "msg": [{".id": "*3", "address": "192.168.58.254/24", "network": "192.168.58.0"}, {".id": "*4", "address": "192.168.58.1/24", "network": "192.168.58.0"}, {".id": "*5", "address": "192.168.58.2/24", "network": "192.168.58.0"}]}

PLAY RECAP *************************************************************************************************************************************************************************************************
10.20.36.253               : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```

3. WHERE with multiple criterias (fixed for libouteros WHERE-AND only - read more)

```
$ ansible-playbook playbooks/ros/testing/ros_query_devel.yml --ask-vault-pass -v -e ros_testing_query="'.id network address WHERE network == 192.168.58.0, address != 192.168.58.254/24'"
Using /opt/gitea/ansible/ansible.cfg as config file
Vault password: 
[WARNING]: An error occurred while calling ansible.utils.display.initialize_locale (unsupported locale setting). This may result in incorrectly calculated text widths that can cause Display to print
incorrect line lengths

PLAY [ros query example] ***********************************************************************************************************************************************************************************

TASK [query in ip address for .id network address WHERE network == 192.168.58.0, address != 192.168.58.254/24] *********************************************************************************************
ok: [10.20.36.253 -> localhost] => {"changed": false, "msg": [{".id": "*4", "address": "192.168.58.1/24", "network": "192.168.58.0"}, {".id": "*5", "address": "192.168.58.2/24", "network": "192.168.58.0"}]}

PLAY RECAP *************************************************************************************************************************************************************************************************
10.20.36.253               : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```

READ MORE: 

I try to not breake additional functionality around api_query() and def __init__() (if self.query:), however in order to achive this I move self.wehre to self.where_list.
As general idea is to take ansible argument, pars evrething after 'WHERE' and make it as proper list format. After that those criteria are processed as list of lists (check api_query())

What I test so far look ok. This code add only AND functionality (aka - a == b and c == d and y == z .. etc.), however I want to add librouteros OR as well, before I add OR I want to have a review to the current changes since OR code will be added around current change.

note: several small fixes are intruduced as well more related to return messages via ansible
note: '.id network address WHERE network == 192.168.58.0, address != 192.168.58.254/24' -> ',' is used to split criteria
note: 'ip address' is used only for simplicity ! (routeros will not allow ducplicated ip addresses). Example for allowed duplicated configs can be firewall rules, ipsec policy, capsman provisioning .. etc.

Please check the code changes, I will appreciate any idea / improvement / bug fix in the current code .. etc. 
If something is not clear/well understandable in the code, let me know.

TODO:
- wait for init review
- add librouteros OR 
- update api documentation 
- unitest

 