### PR TITLE
Handle escape sequence \_ correctly

### DIFF
--- a/changelogs/fragments/89-quoting.yml
+++ b/changelogs/fragments/89-quoting.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "quoting and unquoting filter plugins, api module - handle the escape sequence ``\\_`` correctly as escaping a space and not an underscore (https://github.com/ansible-collections/community.routeros/pull/89)."

--- a/plugins/module_utils/quoting.py
+++ b/plugins/module_utils/quoting.py
@@ -21,7 +21,7 @@ ESCAPE_SEQUENCES = {
     b'\\': b'\\',
     b'?': b'?',
     b'$': b'$',
-    b'_': b'_',
+    b'_': b' ',
     b'a': b'\a',
     b'b': b'\b',
     b'f': b'\xFF',

--- a/tests/ee/roles/filter_quoting/tasks/main.yml
+++ b/tests/ee/roles/filter_quoting/tasks/main.yml
@@ -28,7 +28,7 @@
       - >
         'a=b' | community.routeros.quote_argument == 'a=b'
       - >
-        'a=b c' | community.routeros.quote_argument == 'a="b c"'
+        'a=b c' | community.routeros.quote_argument == 'a="b\\_c"'
       - >
         'a=""' | community.routeros.quote_argument == 'a="\\"\\""'
 
@@ -40,13 +40,13 @@
       - >
         'foo' | community.routeros.quote_argument_value == 'foo'
       - >
-        '"foo bar"' | community.routeros.quote_argument_value == '"\\"foo bar\\""'
+        '"foo bar"' | community.routeros.quote_argument_value == '"\\"foo\\_bar\\""'
 
 - name: "Test join filter"
   assert:
     that:
       - >
-        ['a=', 'b=c d'] | community.routeros.join == 'a="" b="c d"'
+        ['a=', 'b=c d'] | community.routeros.join == 'a="" b="c\\_d"'
 
 - name: "Test list_to_dict filter"
   assert:

--- a/tests/integration/targets/filter_quoting/tasks/main.yml
+++ b/tests/integration/targets/filter_quoting/tasks/main.yml
@@ -28,7 +28,7 @@
       - >
         'a=b' | community.routeros.quote_argument == 'a=b'
       - >
-        'a=b c' | community.routeros.quote_argument == 'a="b c"'
+        'a=b c' | community.routeros.quote_argument == 'a="b\\_c"'
       - >
         'a=""' | community.routeros.quote_argument == 'a="\\"\\""'
 
@@ -40,13 +40,13 @@
       - >
         'foo' | community.routeros.quote_argument_value == 'foo'
       - >
-        '"foo bar"' | community.routeros.quote_argument_value == '"\\"foo bar\\""'
+        '"foo bar"' | community.routeros.quote_argument_value == '"\\"foo\\_bar\\""'
 
 - name: "Test join filter"
   assert:
     that:
       - >
-        ['a=', 'b=c d'] | community.routeros.join == 'a="" b="c d"'
+        ['a=', 'b=c d'] | community.routeros.join == 'a="" b="c\\_d"'
 
 - name: "Test list_to_dict filter"
   assert:

--- a/tests/unit/plugins/module_utils/test_quoting.py
+++ b/tests/unit/plugins/module_utils/test_quoting.py
@@ -34,7 +34,7 @@ TEST_PARSE_ARGUMENT_VALUE = [
     (r'"\\"', {}, ('\\', 4)),
     (r'"\?"', {}, ('?', 4)),
     (r'"\$"', {}, ('$', 4)),
-    (r'"\_"', {}, ('_', 4)),
+    (r'"\_"', {}, (' ', 4)),
     (r'"\a"', {}, ('\a', 4)),
     (r'"\b"', {}, ('\b', 4)),
     (r'"\f"', {}, (to_native(b'\xff'), 4)),
@@ -165,7 +165,7 @@ def test_convert_list_to_dictionary_errors(list, kwargs, message):
 
 
 TEST_JOIN_ROUTEROS_COMMAND = [
-    (['a=b', 'c=d=e', 'e=', 'f', 'g=h i j', 'h="h"'], r'a=b c="d=e" e="" f g="h i j" h="\"h\""'),
+    (['a=b', 'c=d=e', 'e=', 'f', 'g=h i j', 'h="h"'], r'a=b c="d=e" e="" f g="h\_i\_j" h="\"h\""'),
 ]
 
 
@@ -180,8 +180,8 @@ TEST_QUOTE_ROUTEROS_ARGUMENT = [
     (r'', r''),
     (r'a', r'a'),
     (r'a=b', r'a=b'),
-    (r'a=b c', r'a="b c"'),
-    (r'a="b c"', r'a="\"b c\""'),
+    (r'a=b c', r'a="b\_c"'),
+    (r'a="b c"', r'a="\"b\_c\""'),
     (r"a='b", "a=\"'b\""),
     (r"a=b'", "a=\"b'\""),
     (r'a=""', r'a="\"\""'),
@@ -212,19 +212,20 @@ def test_quote_routeros_argument_errors(argument, message):
 TEST_QUOTE_ROUTEROS_ARGUMENT_VALUE = [
     (r'', r'""'),
     (r";", r'";"'),
-    (r" ", r'" "'),
+    (r" ", r'"\_"'),
     (r"=", r'"="'),
     (r'a', r'a'),
     (r'a=b', r'"a=b"'),
-    (r'b c', r'"b c"'),
-    (r'"b c"', r'"\"b c\""'),
+    (r'b c', r'"b\_c"'),
+    (r'"b c"', r'"\"b\_c\""'),
     ("'b", "\"'b\""),
     ("b'", "\"b'\""),
     ('"', r'"\""'),
     ('\\', r'"\\"'),
     ('?', r'"\?"'),
     ('$', r'"\$"'),
-    ('_', r'"\_"'),
+    ('_', r'_'),
+    (' ', r'"\_"'),
     ('\a', r'"\a"'),
     ('\b', r'"\b"'),
     # (to_native(b'\xff'), r'"\f"'),


### PR DESCRIPTION
##### SUMMARY
`\_` means a quoted space, not a quoted underscore.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
(un)quoting filters
api module
