### PR TITLE
Added timeout setting for api.

### DIFF
--- a/changelogs/fragments/109-add-timeout-parameter-to-api.yml
+++ b/changelogs/fragments/109-add-timeout-parameter-to-api.yml
@@ -1,2 +1,2 @@
 minor_changes:
-- "api* modules - added timeout parameter (https://github.com//pull/109)."
+- "api* modules - added ``timeout`` parameter (https://github.com/ansible-collections/community.routeros/pull/109)."

--- a/changelogs/fragments/109-add-timeout-parameter-to-api.yml
+++ b/changelogs/fragments/109-add-timeout-parameter-to-api.yml
@@ -1,2 +1,2 @@
 minor_changes:
-- "api* modules - Added timeout parameter. (https://github.com/ansible-collections/community.routeros/pull/109)."
+- "api* modules - added timeout parameter (https://github.com//pull/109)."

--- a/changelogs/fragments/109-add-timeout-parameter-to-api.yml
+++ b/changelogs/fragments/109-add-timeout-parameter-to-api.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "api* modules - Added timeout parameter. (https://github.com/ansible-collections/community.routeros/pull/109)."

--- a/plugins/doc_fragments/api.py
+++ b/plugins/doc_fragments/api.py
@@ -32,6 +32,7 @@ options:
       - Timeout for the request.
     type: int
     default: 10
+    version_added: 2.3.0
   tls:
     description:
       - If is set TLS will be used for RouterOS API connection.

--- a/plugins/doc_fragments/api.py
+++ b/plugins/doc_fragments/api.py
@@ -27,6 +27,11 @@ options:
       - RouterOS user password.
     required: true
     type: str
+  timeout:
+    description:
+      - Timeout for the request.
+    type: int
+    default: 10
   tls:
     description:
       - If is set TLS will be used for RouterOS API connection.

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -44,11 +44,12 @@ def api_argument_spec():
         validate_certs=dict(type='bool', default=True),
         validate_cert_hostname=dict(type='bool', default=False),
         ca_path=dict(type='path'),
-        encoding=dict(type='str', default='ASCII')
+        encoding=dict(type='str', default='ASCII'),
+        timeout=dict(type='int', default=10)
     )
 
 
-def _ros_api_connect(module, username, password, host, port, use_tls, validate_certs, validate_cert_hostname, ca_path, encoding):
+def _ros_api_connect(module, username, password, host, port, use_tls, validate_certs, validate_cert_hostname, ca_path, encoding, timeout):
     '''Connect to RouterOS API.'''
     if not port:
         if use_tls:
@@ -62,6 +63,7 @@ def _ros_api_connect(module, username, password, host, port, use_tls, validate_c
             host=host,
             port=port,
             encoding=encoding,
+            timeout=timeout,
         )
         if use_tls:
             ctx = ssl.create_default_context(cafile=ca_path)
@@ -103,4 +105,5 @@ def create_api(module):
         module.params['validate_cert_hostname'],
         module.params['ca_path'],
         module.params['encoding'],
+        module.params['timeout'],
     )

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -45,7 +45,7 @@ def api_argument_spec():
         validate_cert_hostname=dict(type='bool', default=False),
         ca_path=dict(type='path'),
         encoding=dict(type='str', default='ASCII'),
-        timeout=dict(type='int', default=10)
+        timeout=dict(type='int', default=10),
     )
 
 


### PR DESCRIPTION
### Added timeout setting for the API request.

At the moment the timeout of librouteros is by default 10 seconds. For some tasks this is to short.
librouteros already provides an option to overwrite the timeout. This commit add the parameter to this module.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Only affects the api part of the module. Added timeout parameter.

##### ADDITIONAL INFORMATION
Sorry don't know how the create the `verbatim` output.
