### PR TITLE
Add new api option force_no_cert

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Example playbook:
       password: "{{ password }}"
       username: "{{ username }}"
       tls: true
+      force_no_cert: false
       validate_certs: true
       validate_cert_hostname: true
       ca_path: /path/to/ca-certificate.pem

--- a/changelogs/fragments/124-api.yml
+++ b/changelogs/fragments/124-api.yml
@@ -1,3 +1,3 @@
 minor_changes:
-  - api - Add new api option ``force_no_cert`` to connect with ADH ciphers
+  - api* modules - Add new option ``force_no_cert`` to connect with ADH ciphers
     (https://github.com/ansible-collections/community.routeros/pull/124).

--- a/changelogs/fragments/124-api.yml
+++ b/changelogs/fragments/124-api.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - api - Add new api option ``force_no_cert`` to connect with ADH ciphers
+    (https://github.com/ansible-collections/community.routeros/pull/124).

--- a/docs/docsite/rst/api-guide.rst
+++ b/docs/docsite/rst/api-guide.rst
@@ -107,6 +107,7 @@ Setting up encryption
 
 It is recommended to always use ``tls: true`` when connecting with the API, even if you are only connecting to the device through a trusted network. The following options control how TLS/SSL is used:
 
+:force_no_cert: Setting to ``true`` connects to the device without a certificate. **This is discouraged to use in production and is susceptible to Man-in-the-Middle attacks**, but might be useful when setting the device up. The default value is ``false``.
 :validate_certs: Setting to ``false`` disables any certificate validation. **This is discouraged to use in production**, but is needed when setting the device up. The default value is ``true``.
 :validate_cert_hostname: Setting to ``false`` (default) disables hostname verification during certificate validation. This is needed if the hostnames specified in the certificate do not match the hostname used for connecting (usually the device's IP). It is recommended to set up the certificate correctly and set this to ``true``; the default ``false`` is chosen for backwards compatibility to an older version of the module.
 :ca_path: If you are not using a commerically trusted CA certificate to sign your device's certificate, or have not included your CA certificate in Python's truststore, you need to point this option to the CA certificate.

--- a/plugins/doc_fragments/api.py
+++ b/plugins/doc_fragments/api.py
@@ -46,6 +46,17 @@ options:
       - RouterOS api port. If I(tls) is set, port will apply to TLS/SSL connection.
       - Defaults are C(8728) for the HTTP API, and C(8729) for the HTTPS API.
     type: int
+  force_no_cert:
+    description:
+      - Set to C(true) to connect without a certificate
+      - See also I(validate_certs).
+      - B(Note:) this forces the use of anonymous Diffie-Hellman (ADH) ciphers. The protocol is susceptible
+        to Man-in-the-Middle attacks, because the keys used in the exchange are not authenticated.
+        Instead of simply connecting without a certificate to "make things work" have a look at
+        I(validate_certs) and I(ca_path).
+    type: bool
+    default: false
+    version_added: 2.4.0
   validate_certs:
     description:
       - Set to C(false) to skip validation of TLS certificates.

--- a/plugins/doc_fragments/api.py
+++ b/plugins/doc_fragments/api.py
@@ -48,7 +48,7 @@ options:
     type: int
   force_no_cert:
     description:
-      - Set to C(true) to connect without a certificate
+      - Set to C(true) to connect without a certificate when I(tls=true).
       - See also I(validate_certs).
       - B(Note:) this forces the use of anonymous Diffie-Hellman (ADH) ciphers. The protocol is susceptible
         to Man-in-the-Middle attacks, because the keys used in the exchange are not authenticated.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Add new option to the api

```
force_no_cert: false
```

Connect to a router without a certificate by using ADH ciphers. This can be useful when setting up a device.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

- api_*

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

When enabling the api-ssl service on RouterOS devices it does not have a certificate, but allows to connect to the device by using the anonymous Diffie-Hellman (ADH) ciphers. This can help during the initial setup.
