### PR TITLE
terminal regex udpate to match the terminal prompt in safe mode

### DIFF
--- a/changelogs/fragments/134-command-safemode.yml
+++ b/changelogs/fragments/134-command-safemode.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - ``command`` module - commands don't timeout in safe mode anymore
+    (https://github.com/ansible-collections/community.routeros/pull/134).

--- a/changelogs/fragments/134-command-safemode.yml
+++ b/changelogs/fragments/134-command-safemode.yml
@@ -1,3 +1,3 @@
 bugfixes:
-  - "``command`` module - commands don't timeout in safe mode anymore
+  - "command, facts - commands do not timeout in safe mode anymore
     (https://github.com/ansible-collections/community.routeros/pull/134)."

--- a/changelogs/fragments/134-command-safemode.yml
+++ b/changelogs/fragments/134-command-safemode.yml
@@ -1,3 +1,3 @@
 bugfixes:
-  - ``command`` module - commands don't timeout in safe mode anymore
-    (https://github.com/ansible-collections/community.routeros/pull/134).
+  - "``command`` module - commands don't timeout in safe mode anymore
+    (https://github.com/ansible-collections/community.routeros/pull/134)."

--- a/plugins/terminal/routeros.py
+++ b/plugins/terminal/routeros.py
@@ -33,7 +33,7 @@ class TerminalModule(TerminalBase):
 
     terminal_stdout_re = [
         re.compile(br"\x1b<"),
-        re.compile(br"\[[\w\-\.]+\@[\w\s\-\.\/]+\] ?> ?$"),
+        re.compile(br"\[[\w\-\.]+\@[\w\s\-\.\/]+\] ?(<SAFE)?> ?$"),
         re.compile(br"Please press \"Enter\" to continue!"),
         re.compile(br"Do you want to see the software license\? \[Y\/n\]: ?"),
     ]


### PR DESCRIPTION
##### SUMMARY
Updating the regex that matches the terminal prompt for ``command`` module in safe mode. 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
command

##### ADDITIONAL INFORMATION

Commands are timing out in safe mode now, because the module will never match the terminal prompt which is required in order to recognize the end of the command output. 

In order to try the functionality, ``CTRL + X`` (``\x18``) has to be passed as a command to the module.