### PR TITLE
Add wireguard interface and peers

### DIFF
--- a/changelogs/fragments/143-add-wireguard.yml
+++ b/changelogs/fragments/143-add-wireguard.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - api_modify, api_info - support API paths ``interface wireguard``, ``interface wireguard peers`` (https://github.com/ansible-collections/community.routeros/pull/143).

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -1150,6 +1150,33 @@ PATHS = {
             'verify-client-certificate': KeyInfo(default='no'),
         },
     ),
+    ('interface', 'wireguard'): APIData(
+        fully_understood=True,
+        primary_keys=('name', ),
+        fields={
+            'comment': KeyInfo(can_disable=True, remove_value=''),
+            'disabled': KeyInfo(default=False),
+            'listen-port': KeyInfo(),
+            'mtu': KeyInfo(default=1420),
+            'name': KeyInfo(),
+            'private-key': KeyInfo(),
+        },
+    ),
+    ('interface', 'wireguard', 'peers'): APIData(
+        fully_understood=True,
+        primary_keys=('public-key', 'interface'),
+        fields={
+            'allowed-address': KeyInfo(),
+            'comment': KeyInfo(can_disable=True, remove_value=''),
+            'disabled': KeyInfo(default=False),
+            'endpoint-address': KeyInfo(),
+            'endpoint-port': KeyInfo(default=0),
+            'interface': KeyInfo(),
+            'persistent-keepalive': KeyInfo(),
+            'preshared-key': KeyInfo(),
+            'public-key': KeyInfo(),
+        },
+    ),
     ('interface', 'wireless', 'align'): APIData(
         single_value=True,
         fully_understood=True,

--- a/plugins/modules/api_info.py
+++ b/plugins/modules/api_info.py
@@ -75,6 +75,8 @@ options:
         - interface sstp-server server
         - interface vlan
         - interface vrrp
+        - interface wireguard
+        - interface wireguard peers
         - interface wireless align
         - interface wireless cap
         - interface wireless sniffer

--- a/plugins/modules/api_modify.py
+++ b/plugins/modules/api_modify.py
@@ -80,6 +80,8 @@ options:
         - interface sstp-server server
         - interface vlan
         - interface vrrp
+        - interface wireguard
+        - interface wireguard peers
         - interface wireless align
         - interface wireless cap
         - interface wireless sniffer


### PR DESCRIPTION
##### SUMMARY

Adds support for configuring wireguard interfaces and peers.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

* api_modify
* api_info

##### ADDITIONAL INFORMATION

Missing tests and equally as important, `interface wireguard` editing doesn't behave as expected (misconfiguration error, see below). The API obfuscates the value of `private-key` so the diff is broken, for example:

```
--- before
+++ after
@@ -6,7 +6,7 @@
             "listen-port": 13231,
             "mtu": 1420,
             "name": "WG1",
-            "private-key": "*****"
+            "private-key": "mLh5K+/uJmZJ1zqarPYh0OyBaCgI1n+xAUBvsPBC+3I="
         }
     ]
 }
```

This happens even if that private key is already configured on the router. I was unable to find documentation on how to get the API to return sensitive information like this.

UPDATE: This is fixed by adding the "sensitive" policy to the group used to connect.

```
/user/group> set ansible policy=read,write,api,sensitive
```

After that, the private-key is returned and diff works as expected.