### PR TITLE
Correction and Bugfix for ip dhcp-server network

### DIFF
--- a/changelogs/fragments/156-ip_dhcp-server_network.yml
+++ b/changelogs/fragments/156-ip_dhcp-server_network.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - api_modify - Adapt data for API paths "ip dhcp-server network" (https://github.com/ansible-collections/community.routeros/pull/156).
+  - api_modify - adapt data for API paths ``ip dhcp-server network`` (https://github.com/ansible-collections/community.routeros/pull/156).

--- a/changelogs/fragments/156-ip_dhcp-server_network.yml
+++ b/changelogs/fragments/156-ip_dhcp-server_network.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - api_modify - Adapt data for API paths "ip dhcp-server network" (https://github.com/ansible-collections/community.routeros/pull/156).

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -1361,7 +1361,7 @@ PATHS = {
             'domain': KeyInfo(default=''),
             'gateway': KeyInfo(automatically_computed_from=('address', )),
             'netmask': KeyInfo(can_disable=True, remove_value=0),
-            'next-server': KeyInfo(default=''),
+            'next-server': KeyInfo(can_disable=True),
             'ntp-server': KeyInfo(default=''),
             'wins-server': KeyInfo(default=''),
         },

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -1359,7 +1359,7 @@ PATHS = {
             'dns-none': KeyInfo(default=''),
             'dns-server': KeyInfo(default=''),
             'domain': KeyInfo(default=''),
-            'gateway': KeyInfo(automatically_computed_from=('address', )),
+            'gateway': KeyInfo(default=''),
             'netmask': KeyInfo(can_disable=True, remove_value=0),
             'next-server': KeyInfo(can_disable=True),
             'ntp-server': KeyInfo(default=''),

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -1356,7 +1356,7 @@ PATHS = {
             'comment': KeyInfo(can_disable=True, remove_value=''),
             'dhcp-option': KeyInfo(default=''),
             'dhcp-option-set': KeyInfo(default=''),
-            'dns-none': KeyInfo(default=''),
+            'dns-none': KeyInfo(default=False),
             'dns-server': KeyInfo(default=''),
             'domain': KeyInfo(default=''),
             'gateway': KeyInfo(default=''),

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -1360,7 +1360,7 @@ PATHS = {
             'dns-server': KeyInfo(default=''),
             'domain': KeyInfo(default=''),
             'gateway': KeyInfo(automatically_computed_from=('address', )),
-            'netmask': KeyInfo(automatically_computed_from=('address', )),
+            'netmask': KeyInfo(can_disable=True, remove_value=0),
             'next-server': KeyInfo(default=''),
             'ntp-server': KeyInfo(default=''),
             'wins-server': KeyInfo(default=''),


### PR DESCRIPTION
##### SUMMARY
Adapt data for API paths "ip dhcp-server network"
Bug solved: when a next-server is configured, it's impossible to remove it.  
- When trying with `''` : `invalid value for argument next-server`
- When trying with `None` : `Key \"next-server\" must not be disabled (value null/~/None)`

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
ip dhcp-server network

