### PR TITLE
Integration tests: use failed_when instead of ignore_errors

### DIFF
--- a/tests/integration/targets/filter_quoting/tasks/main.yml
+++ b/tests/integration/targets/filter_quoting/tasks/main.yml
@@ -15,8 +15,8 @@
   set_fact:
     test: >-
       {{ 'a="' | community.routeros.split }}
-  ignore_errors: true
   register: result
+  failed_when: result is not failed
 
 - name: "Verify split filter error handling"
   assert:


### PR DESCRIPTION
##### SUMMARY
This is more explicit what the intent is.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
integration tests
