### PR TITLE
Fixes #179: Add missing /tool/e-mail parameter "tls"

### DIFF
--- a/changelogs/fragments/180-fix-tls-in-tool-email.yml
+++ b/changelogs/fragments/180-fix-tls-in-tool-email.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - community.routeros.api_modify - fix missing parameter ``tls`` for ``/tool/e-mail``. The error ``FAILED! => {"changed": false, "msg": "Unknown key \"tls\"."}`` was raised (https://github.com/ansible-collections/community.routeros/issues/179).

--- a/changelogs/fragments/180-fix-tls-in-tool-email.yml
+++ b/changelogs/fragments/180-fix-tls-in-tool-email.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - community.routeros.api_modify - fix missing parameter ``tls`` for ``/tool/e-mail``. The error ``FAILED! => {"changed": false, "msg": "Unknown key \"tls\"."}`` was raised (https://github.com/ansible-collections/community.routeros/issues/179).
+  - api_modify, api_info - add missing parameter ``tls`` for the ``tool e-mail`` path (https://github.com/ansible-collections/community.routeros/issues/179, https://github.com/ansible-collections/community.routeros/pull/180).

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -2451,6 +2451,7 @@ PATHS = {
             'password': KeyInfo(default=''),
             'port': KeyInfo(default=25),
             'start-tls': KeyInfo(default=False),
+            'tls': KeyInfo(default=False),
             'user': KeyInfo(default=''),
         },
     ),


### PR DESCRIPTION
##### SUMMARY
Fixes #179: Add missing /tool/e-mail parameter "tls"

In the
[documentation](https://help.mikrotik.com/docs/display/ROS/E-mail#Email-Properties) the parameter "tls" is mentioned but it cannot be used. The old "start-tls" parameter is not mentioned there (only on the [old documentation](https://wiki.mikrotik.com/wiki/Manual:Tools/email#Properties)). Trying to use the paramter "tls" lead to the erro message `FAILED! => {"changed": false, "msg": "Unknown key \"tls\"."}`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
community.routeros.api_modify

##### ADDITIONAL INFORMATION
None.