### PR TITLE
CI: Bump hard-coded Python versions to 3.11; drop Python 3.9 with devel

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -109,7 +109,6 @@ jobs:
         ansible:
           - devel
         python:
-          - 3.9
           - "3.10"
           - "3.11"
         include:
@@ -134,10 +133,10 @@ jobs:
             python: "3.10"
           # 2.14
           - ansible: stable-2.14
-            python: "3.9"
+            python: "3.11"
           # 2.15
           - ansible: stable-2.15
-            python: "3.11"
+            python: "3.9"
 
     steps:
       - name: >-

--- a/.github/workflows/extra-tests.yml
+++ b/.github/workflows/extra-tests.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install ansible-core
         run: pip install https://github.com/ansible/ansible/archive/devel.tar.gz --disable-pip-version-check

--- a/.github/workflows/import-galaxy.yml
+++ b/.github/workflows/import-galaxy.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install ansible-core
         run: pip install https://github.com/ansible/ansible/archive/devel.tar.gz --disable-pip-version-check
@@ -71,7 +71,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install ansible-core
         run: pip install https://github.com/ansible/ansible/archive/devel.tar.gz --disable-pip-version-check


### PR DESCRIPTION
##### SUMMARY
Bump hard-coded Python versions in workflows from 3.10 to 3.11.
Also drop Python 3.9 run for devel.

Ref: https://github.com/ansible-collections/news-for-maintainers/issues/48

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
