### PR TITLE
Fixes #189: Add missing /snmp parameter "engine-id-suffix"

### DIFF
--- a/changelogs/fragments/180-fix-engine-id-suffix-in-snmp.yml
+++ b/changelogs/fragments/180-fix-engine-id-suffix-in-snmp.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - api_modify, api_info - add missing parameter ``engine-id-suffix`` for the ``snmp`` path (https://github.com/ansible-collections/community.routeros/issues/189, https://github.com/ansible-collections/community.routeros/pull/190)
+  - api_modify, api_info - add missing parameter ``engine-id-suffix`` for the ``snmp`` path (https://github.com/ansible-collections/community.routeros/issues/189, https://github.com/ansible-collections/community.routeros/pull/190).

--- a/changelogs/fragments/180-fix-engine-id-suffix-in-snmp.yml
+++ b/changelogs/fragments/180-fix-engine-id-suffix-in-snmp.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - api_modify, api_info - add missing parameter ``engine-id-suffix`` for the ``snmp`` path (https://github.com/ansible-collections/community.routeros/issues/189, https://github.com/ansible-collections/community.routeros/pull/190)

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -2280,6 +2280,7 @@ PATHS = {
             'contact': KeyInfo(default=''),
             'enabled': KeyInfo(default=False),
             'engine-id': KeyInfo(default=''),
+            'engine-id-suffix': KeyInfo(default=''),
             'location': KeyInfo(default=''),
             'src-address': KeyInfo(default='::'),
             'trap-community': KeyInfo(default='public'),


### PR DESCRIPTION
##### SUMMARY
Fixes #189: Add missing /snmp parameter "engine-id-suffix"

In the [documentation](https://help.mikrotik.com/docs/display/ROS/SNMP#SNMP-GeneralProperties) it is not (yet) updated but at least on version 7.10 it is already changed.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
community.routeros.api_modify

##### ADDITIONAL INFORMATION
None
