### PR TITLE
Support "address-list" and "match-subdomain" in static DNS records

### DIFF
--- a/changelogs/fragments/197-dns-static-addrlist-matchsubdomain.yml
+++ b/changelogs/fragments/197-dns-static-addrlist-matchsubdomain.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - api_info, api_modify - add support for ``address-list`` and ``match-subdomain`` introduced by RouterOS 7.7 in the ``ip dns static`` path (https://github.com/ansible-collections/community.routeros/pull/197).

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -1408,10 +1408,12 @@ PATHS = {
         mutually_exclusive=[['name', 'regexp']],
         fields={
             'address': KeyInfo(),
+            'address-list': KeyInfo(),
             'cname': KeyInfo(),
             'comment': KeyInfo(can_disable=True, remove_value=''),
             'disabled': KeyInfo(default=False),
             'forward-to': KeyInfo(),
+            'match-subdomain': KeyInfo(default=False),
             'mx-exchange': KeyInfo(),
             'mx-preference': KeyInfo(),
             'name': KeyInfo(),

--- a/tests/unit/plugins/modules/test_api_find_and_modify.py
+++ b/tests/unit/plugins/modules/test_api_find_and_modify.py
@@ -389,6 +389,7 @@ class TestRouterosApiFindAndModifyModule(ModuleTestCase):
                 'ttl': '1d',
                 'disabled': False,
                 'dynamic': False,
+                'match-subdomain': False,
             },
             {
                 '.id': '*A',
@@ -397,6 +398,7 @@ class TestRouterosApiFindAndModifyModule(ModuleTestCase):
                 'ttl': '1d',
                 'disabled': False,
                 'dynamic': False,
+                'match-subdomain': False,
             },
             {
                 '.id': '*7',
@@ -406,6 +408,7 @@ class TestRouterosApiFindAndModifyModule(ModuleTestCase):
                 'ttl': '1d',
                 'disabled': False,
                 'dynamic': False,
+                'match-subdomain': False,
             },
         ])
         self.assertEqual(result['diff']['before']['values'], [
@@ -416,6 +419,7 @@ class TestRouterosApiFindAndModifyModule(ModuleTestCase):
                 'ttl': '1d',
                 'disabled': False,
                 'dynamic': False,
+                'match-subdomain': False,
             },
         ])
         self.assertEqual(result['diff']['after']['values'], [
@@ -427,6 +431,7 @@ class TestRouterosApiFindAndModifyModule(ModuleTestCase):
                 'ttl': '1d',
                 'disabled': False,
                 'dynamic': False,
+                'match-subdomain': False,
             },
         ])
         self.assertEqual(result['match_count'], 1)
@@ -459,6 +464,7 @@ class TestRouterosApiFindAndModifyModule(ModuleTestCase):
                 'ttl': '1d',
                 'disabled': False,
                 'dynamic': False,
+                'match-subdomain': False,
             },
             {
                 '.id': '*A',
@@ -467,6 +473,7 @@ class TestRouterosApiFindAndModifyModule(ModuleTestCase):
                 'ttl': '1d',
                 'disabled': False,
                 'dynamic': False,
+                'match-subdomain': False,
             },
             {
                 '.id': '*7',
@@ -475,6 +482,7 @@ class TestRouterosApiFindAndModifyModule(ModuleTestCase):
                 'ttl': '1d',
                 'disabled': False,
                 'dynamic': False,
+                'match-subdomain': False,
             },
         ])
         self.assertEqual('diff' in result, False)
@@ -508,6 +516,7 @@ class TestRouterosApiFindAndModifyModule(ModuleTestCase):
                 'ttl': '1d',
                 'disabled': False,
                 'dynamic': False,
+                'match-subdomain': False,
             },
             {
                 '.id': '*A',
@@ -516,6 +525,7 @@ class TestRouterosApiFindAndModifyModule(ModuleTestCase):
                 'ttl': '1d',
                 'disabled': False,
                 'dynamic': False,
+                'match-subdomain': False,
             },
             {
                 '.id': '*7',
@@ -524,6 +534,7 @@ class TestRouterosApiFindAndModifyModule(ModuleTestCase):
                 'ttl': '1d',
                 'disabled': False,
                 'dynamic': False,
+                'match-subdomain': False,
             },
         ])
         self.assertEqual(result['match_count'], 3)
@@ -556,6 +567,7 @@ class TestRouterosApiFindAndModifyModule(ModuleTestCase):
                 'ttl': '1d',
                 'disabled': False,
                 'dynamic': False,
+                'match-subdomain': False,
             },
             {
                 '.id': '*A',
@@ -564,6 +576,7 @@ class TestRouterosApiFindAndModifyModule(ModuleTestCase):
                 'ttl': '1d',
                 'disabled': False,
                 'dynamic': False,
+                'match-subdomain': False,
             },
             {
                 '.id': '*7',
@@ -572,6 +585,7 @@ class TestRouterosApiFindAndModifyModule(ModuleTestCase):
                 'ttl': '1d',
                 'disabled': False,
                 'dynamic': False,
+                'match-subdomain': False,
             },
         ])
         self.assertEqual(result['match_count'], 3)

--- a/tests/unit/plugins/modules/test_api_modify.py
+++ b/tests/unit/plugins/modules/test_api_modify.py
@@ -600,6 +600,7 @@ class TestRouterosApiModifyModule(ModuleTestCase):
                 'address': '192.168.88.1',
                 'ttl': '1d',
                 'disabled': False,
+                'match-subdomain': False,
             },
             {
                 '.id': '*A',
@@ -607,6 +608,7 @@ class TestRouterosApiModifyModule(ModuleTestCase):
                 'text': 'Router Text Entry',
                 'ttl': '1d',
                 'disabled': False,
+                'match-subdomain': False,
             },
             {
                 '.id': '*7',
@@ -614,6 +616,7 @@ class TestRouterosApiModifyModule(ModuleTestCase):
                 'address': '192.168.88.2',
                 'ttl': '1d',
                 'disabled': False,
+                'match-subdomain': False,
             },
             {
                 '.id': '*NEW1',
@@ -621,6 +624,7 @@ class TestRouterosApiModifyModule(ModuleTestCase):
                 'text': 'Router Text Entry 2',
                 'ttl': '1d',
                 'disabled': False,
+                'match-subdomain': False,
             },
         ])
 
@@ -661,6 +665,7 @@ class TestRouterosApiModifyModule(ModuleTestCase):
                 'address': '192.168.88.1',
                 'ttl': '1d',
                 'disabled': False,
+                'match-subdomain': False,
             },
             {
                 '.id': '*A',
@@ -668,6 +673,7 @@ class TestRouterosApiModifyModule(ModuleTestCase):
                 'text': 'Router Text Entry',
                 'ttl': '1d',
                 'disabled': False,
+                'match-subdomain': False,
             },
             {
                 '.id': '*7',
@@ -675,6 +681,7 @@ class TestRouterosApiModifyModule(ModuleTestCase):
                 'address': '192.168.88.2',
                 'ttl': '1d',
                 'disabled': False,
+                'match-subdomain': False,
             },
             {
                 '.id': '*NEW1',
@@ -682,6 +689,7 @@ class TestRouterosApiModifyModule(ModuleTestCase):
                 'text': 'Router Text Entry 2',
                 'ttl': '1d',
                 'disabled': False,
+                'match-subdomain': False,
             },
         ])
 
@@ -723,6 +731,7 @@ class TestRouterosApiModifyModule(ModuleTestCase):
                 'address': '192.168.88.1',
                 'ttl': '1d',
                 'disabled': False,
+                'match-subdomain': False,
             },
             {
                 '.id': '*A',
@@ -730,6 +739,7 @@ class TestRouterosApiModifyModule(ModuleTestCase):
                 'text': 'Router Text Entry',
                 'ttl': '1d',
                 'disabled': False,
+                'match-subdomain': False,
             },
             {
                 '.id': '*7',
@@ -737,6 +747,7 @@ class TestRouterosApiModifyModule(ModuleTestCase):
                 'address': '192.168.88.2',
                 'ttl': '1d',
                 'disabled': False,
+                'match-subdomain': False,
             },
             {
                 'name': 'router',
@@ -782,6 +793,7 @@ class TestRouterosApiModifyModule(ModuleTestCase):
                 'address': '192.168.88.1',
                 'ttl': '1d',
                 'disabled': False,
+                'match-subdomain': False,
             },
             {
                 '.id': '*A',
@@ -789,6 +801,7 @@ class TestRouterosApiModifyModule(ModuleTestCase):
                 'text': 'Router Text Entry 2',
                 'ttl': '1d',
                 'disabled': False,
+                'match-subdomain': False,
             },
             {
                 '.id': '*7',
@@ -796,6 +809,7 @@ class TestRouterosApiModifyModule(ModuleTestCase):
                 'address': '192.168.88.2',
                 'ttl': '1d',
                 'disabled': False,
+                'match-subdomain': False,
             },
         ])
 
@@ -838,6 +852,7 @@ class TestRouterosApiModifyModule(ModuleTestCase):
                 'address': '192.168.88.1',
                 'ttl': '1d',
                 'disabled': False,
+                'match-subdomain': False,
             },
             {
                 '.id': '*A',
@@ -845,6 +860,7 @@ class TestRouterosApiModifyModule(ModuleTestCase):
                 'text': 'Router Text Entry 2',
                 'ttl': '1d',
                 'disabled': False,
+                'match-subdomain': False,
             },
             {
                 '.id': '*7',
@@ -852,6 +868,7 @@ class TestRouterosApiModifyModule(ModuleTestCase):
                 'address': '192.168.88.2',
                 'ttl': '1d',
                 'disabled': False,
+                'match-subdomain': False,
             },
         ])
 
@@ -894,6 +911,7 @@ class TestRouterosApiModifyModule(ModuleTestCase):
                 'address': '192.168.88.1',
                 'ttl': '1d',
                 'disabled': False,
+                'match-subdomain': False,
             },
             {
                 '.id': '*7',
@@ -901,6 +919,7 @@ class TestRouterosApiModifyModule(ModuleTestCase):
                 'address': '192.168.88.2',
                 'ttl': '1d',
                 'disabled': False,
+                'match-subdomain': False,
             },
             {
                 '.id': '*NEW1',
@@ -908,6 +927,7 @@ class TestRouterosApiModifyModule(ModuleTestCase):
                 'cname': 'router.com.',
                 'ttl': '1d',
                 'disabled': False,
+                'match-subdomain': False,
             },
         ])
 
@@ -951,6 +971,7 @@ class TestRouterosApiModifyModule(ModuleTestCase):
                 'address': '192.168.88.1',
                 'ttl': '1d',
                 'disabled': False,
+                'match-subdomain': False,
             },
             {
                 '.id': '*7',
@@ -958,6 +979,7 @@ class TestRouterosApiModifyModule(ModuleTestCase):
                 'address': '192.168.88.2',
                 'ttl': '1d',
                 'disabled': False,
+                'match-subdomain': False,
             },
             {
                 'name': 'router',
@@ -1003,6 +1025,7 @@ class TestRouterosApiModifyModule(ModuleTestCase):
                 'address': '192.168.88.1',
                 'ttl': '1d',
                 'disabled': False,
+                'match-subdomain': False,
             },
             {
                 '.id': '*A',
@@ -1011,6 +1034,7 @@ class TestRouterosApiModifyModule(ModuleTestCase):
                 'text': 'Router Text Entry 2',
                 'ttl': '1d',
                 'disabled': False,
+                'match-subdomain': False,
             },
             {
                 '.id': '*7',
@@ -1018,6 +1042,7 @@ class TestRouterosApiModifyModule(ModuleTestCase):
                 'address': '192.168.88.2',
                 'ttl': '1d',
                 'disabled': False,
+                'match-subdomain': False,
             },
         ])
 
@@ -1060,6 +1085,7 @@ class TestRouterosApiModifyModule(ModuleTestCase):
                 'address': '192.168.88.1',
                 'ttl': '1d',
                 'disabled': False,
+                'match-subdomain': False,
             },
             {
                 '.id': '*A',
@@ -1068,6 +1094,7 @@ class TestRouterosApiModifyModule(ModuleTestCase):
                 'text': 'Router Text Entry 2',
                 'ttl': '1d',
                 'disabled': False,
+                'match-subdomain': False,
             },
             {
                 '.id': '*7',
@@ -1075,6 +1102,7 @@ class TestRouterosApiModifyModule(ModuleTestCase):
                 'address': '192.168.88.2',
                 'ttl': '1d',
                 'disabled': False,
+                'match-subdomain': False,
             },
         ])
 
@@ -1109,6 +1137,7 @@ class TestRouterosApiModifyModule(ModuleTestCase):
                 'address': '192.168.88.1',
                 'ttl': '1d',
                 'disabled': False,
+                'match-subdomain': False,
             },
         ])
 
@@ -1144,6 +1173,7 @@ class TestRouterosApiModifyModule(ModuleTestCase):
                 'address': '192.168.88.1',
                 'ttl': '1d',
                 'disabled': False,
+                'match-subdomain': False,
             },
         ])
 
@@ -1190,6 +1220,7 @@ class TestRouterosApiModifyModule(ModuleTestCase):
                 'address': '192.168.88.2',
                 'ttl': '1d',
                 'disabled': False,
+                'match-subdomain': False,
             },
             {
                 '.id': '*NEW1',
@@ -1197,6 +1228,7 @@ class TestRouterosApiModifyModule(ModuleTestCase):
                 'text': 'bar',
                 'ttl': '1d',
                 'disabled': False,
+                'match-subdomain': False,
             },
             {
                 '.id': '*A',
@@ -1204,6 +1236,7 @@ class TestRouterosApiModifyModule(ModuleTestCase):
                 'text': 'Router Text Entry',
                 'ttl': '1d',
                 'disabled': False,
+                'match-subdomain': False,
             },
             {
                 '.id': '*1',
@@ -1212,6 +1245,7 @@ class TestRouterosApiModifyModule(ModuleTestCase):
                 'address': '192.168.88.1',
                 'ttl': '1d',
                 'disabled': False,
+                'match-subdomain': False,
             },
         ])
 
@@ -1259,6 +1293,7 @@ class TestRouterosApiModifyModule(ModuleTestCase):
                 'address': '192.168.88.2',
                 'ttl': '1d',
                 'disabled': False,
+                'match-subdomain': False,
             },
             {
                 'name': 'foo',
@@ -1270,6 +1305,7 @@ class TestRouterosApiModifyModule(ModuleTestCase):
                 'text': 'Router Text Entry',
                 'ttl': '1d',
                 'disabled': False,
+                'match-subdomain': False,
             },
             {
                 '.id': '*1',
@@ -1278,6 +1314,7 @@ class TestRouterosApiModifyModule(ModuleTestCase):
                 'address': '192.168.88.1',
                 'ttl': '1d',
                 'disabled': False,
+                'match-subdomain': False,
             },
         ])
 


### PR DESCRIPTION
##### SUMMARY
RouterOS 7.5 added `address-list` and `match-subdomain` as fields for static DNS records ([changelog](https://forum.mikrotik.com/viewtopic.php?t=188851)).

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
community.routeros