### PR TITLE
Support "mode" in IPv4 neighbor discovery configuration

### DIFF
--- a/changelogs/fragments/198-ip-nd-mode.yml
+++ b/changelogs/fragments/198-ip-nd-mode.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - api_info, api_modify - add support for the ``mode`` property in ``ip neighbor discovery-settings`` introduced in RouterOS 7.7 (https://github.com/ansible-collections/community.routeros/pull/198).

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -1020,6 +1020,7 @@ PATHS = {
         fields={
             'discover-interface-list': KeyInfo(),
             'lldp-med-net-policy-vlan': KeyInfo(default='disabled'),
+            'mode': KeyInfo(default='tx-and-rx'),
             'protocol': KeyInfo(default='cdp,lldp,mndp'),
         },
     ),


### PR DESCRIPTION
##### SUMMARY
RouterOS 7.7 added a `mode` parameter to the IPv4 neighbor discovery configuration ([changelog](https://forum.mikrotik.com/viewtopic.php?t=192427)).

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
community.routeros