### PR TITLE
Add "apn", remove "running" property for ppp-client interfaces

### DIFF
--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -304,6 +304,7 @@ PATHS = {
         fields={
             'add-default-route': KeyInfo(default=True),
             'allow': KeyInfo(default='pap,chap,mschap1,mschap2'),
+            'apn': KeyInfo(default='internet'),
             'comment': KeyInfo(can_disable=True, remove_value=''),
             'data-channel': KeyInfo(default=0),
             'default-route-distance': KeyInfo(default=1),
@@ -323,7 +324,6 @@ PATHS = {
             'pin': KeyInfo(default=''),
             'port': KeyInfo(),
             'profile': KeyInfo(default='default'),
-            'running': KeyInfo(default=False),
             'use-peer-dns': KeyInfo(default=True),
             'user': KeyInfo(default=''),
         },


### PR DESCRIPTION
##### SUMMARY
Commit 2164261 from #199 added support for `interface ppp-client`. It missed the `apn` property and added the runtime-only `running` property.

No changelog fragment is included as this is a pre-release bugfix.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
community.routeros