### PR TITLE
Add support for "iot modbus"

### DIFF
--- a/changelogs/fragments/205-add-iot-modbus.yml
+++ b/changelogs/fragments/205-add-iot-modbus.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - api_info, api_modify - add support for the ``iot modbus`` path (https://github.com/ansible-collections/community.routeros/pull/205).

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -1423,6 +1423,16 @@ PATHS = {
             'receive-errors': KeyInfo(default=False),
         },
     ),
+    ('iot', 'modbus'): APIData(
+        single_value=True,
+        fully_understood=True,
+        fields={
+            'disabled': KeyInfo(default=True),
+            'hardware-port': KeyInfo(default='modbus'),
+            'tcp-port': KeyInfo(default=502),
+            'timeout': KeyInfo(default=1000),
+        },
+    ),
     ('ip', 'accounting'): APIData(
         single_value=True,
         fully_understood=True,

--- a/plugins/modules/api_info.py
+++ b/plugins/modules/api_info.py
@@ -86,6 +86,7 @@ options:
         - interface wireless security-profiles
         - interface wireless sniffer
         - interface wireless snooper
+        - iot modbus
         - ip accounting
         - ip accounting web-access
         - ip address

--- a/plugins/modules/api_modify.py
+++ b/plugins/modules/api_modify.py
@@ -91,6 +91,7 @@ options:
         - interface wireless security-profiles
         - interface wireless sniffer
         - interface wireless snooper
+        - iot modbus
         - ip accounting
         - ip accounting web-access
         - ip address


### PR DESCRIPTION
##### SUMMARY

The default values match those of RouterOS 7.11 on a Mikrotik RB924i-2nD-BT5&BG77 ("Knot").

[Upstream documentation](https://help.mikrotik.com/docs/pages/viewpage.action?pageId=61046813).

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
community.routeros