### PR TITLE
Support "date", "time" and "gmt-offset" in "system clock"

### DIFF
--- a/changelogs/fragments/210-date-time-gmt-offset.yml
+++ b/changelogs/fragments/210-date-time-gmt-offset.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - api_info, api_modify - add support for ``user``, ``time`` and ``gmt-offset`` under the ``system clock`` path (https://github.com/ansible-collections/community.routeros/pull/210).

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -2551,6 +2551,9 @@ PATHS = {
         single_value=True,
         fully_understood=True,
         fields={
+            'date': KeyInfo(),
+            'gmt-offset': KeyInfo(),
+            'time': KeyInfo(),
             'time-zone-autodetect': KeyInfo(default=True),
             'time-zone-name': KeyInfo(default='manual'),
         },


### PR DESCRIPTION
##### SUMMARY
These properties are necessary to read and set the time as seen by RouterOS.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
community.routeros