### PR TITLE
Add support for the "user" path

### DIFF
--- a/changelogs/fragments/211-user.yml
+++ b/changelogs/fragments/211-user.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - api_info, api_modify - add support for the ``user`` path (https://github.com/ansible-collections/community.routeros/pull/211).

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -3282,6 +3282,20 @@ PATHS = {
             },
         ),
     ),
+    ('user',): APIData(
+        unversioned=VersionedAPIData(
+            primary_keys=('name', ),
+            fully_understood=True,
+            fields={
+                'address': KeyInfo(),
+                'comment': KeyInfo(can_disable=True, remove_value=''),
+                'disabled': KeyInfo(default=False),
+                'group': KeyInfo(),
+                'name': KeyInfo(),
+                'password': KeyInfo(write_only=True),
+            },
+        ),
+    ),
     ('user', 'aaa'): APIData(
         unversioned=VersionedAPIData(
             single_value=True,

--- a/plugins/modules/api_info.py
+++ b/plugins/modules/api_info.py
@@ -195,6 +195,7 @@ options:
         - tool sms
         - tool sniffer
         - tool traffic-generator
+        - user
         - user aaa
         - user group
         - user settings

--- a/plugins/modules/api_modify.py
+++ b/plugins/modules/api_modify.py
@@ -204,6 +204,7 @@ options:
         - tool sms
         - tool sniffer
         - tool traffic-generator
+        - user
         - user aaa
         - user group
         - user settings


### PR DESCRIPTION
##### SUMMARY
Make it possible to manage users via the `user` path.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
community.routeros