### PR TITLE
Fix snmp path's engine-id/engine-id-suffix for ROS 7.10+

### DIFF
--- a/changelogs/fragments/218-snmp-engine-id.yml
+++ b/changelogs/fragments/218-snmp-engine-id.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "api_info, api_modify - in the ``snmp`` path, ensure that ``engine-id-suffix`` is only available on RouterOS 7.10+, and that ``engine-id`` is read-only on RouterOS 7.10+ (https://github.com/ansible-collections/community.routeros/issues/208, https://github.com/ansible-collections/community.routeros/pull/218)."

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -2920,8 +2920,6 @@ PATHS = {
             fields={
                 'contact': KeyInfo(default=''),
                 'enabled': KeyInfo(default=False),
-                'engine-id': KeyInfo(default=''),
-                'engine-id-suffix': KeyInfo(default=''),
                 'location': KeyInfo(default=''),
                 'src-address': KeyInfo(default='::'),
                 'trap-community': KeyInfo(default='public'),
@@ -2930,6 +2928,11 @@ PATHS = {
                 'trap-version': KeyInfo(default=1),
                 'trap-interfaces': KeyInfo(default=''),
             },
+            versioned_fields=[
+                ([('7.10', '<')], 'engine-id', KeyInfo(default='')),
+                ([('7.10', '>=')], 'engine-id', KeyInfo(read_only=True)),
+                ([('7.10', '>=')], 'engine-id-suffix', KeyInfo(default='')),
+            ],
         ),
     ),
     ('system', 'clock'): APIData(


### PR DESCRIPTION
##### SUMMARY
Fixes #208.

CC @phox142 @derdeagle (#217) - PTAL!

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
API data
