### PR TITLE
Fix for "'VersionedAPIData' object has no attribute 'fully_supported'"

### DIFF
--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -59,11 +59,11 @@ class APIData(object):
         for other_version, comparator, data in self.versioned:
             if other_version == '*' and comparator == '*':
                 self._current = data.specialize_for_version(api_version)
-                return self._current.fully_supported
+                return self._current.fully_understood
             other_api_version = LooseVersion(other_version)
             if _compare(api_version, other_api_version, comparator):
                 self._current = data.specialize_for_version(api_version)
-                return self._current.fully_supported
+                return self._current.fully_understood
         self._current = None
         return False
 


### PR DESCRIPTION
##### SUMMARY
Commit 4b09951 added code looking for a non-existent `fully_supported` attribute.

##### ISSUE TYPE
- Bugfix Pull Request
