### PR TITLE
Make wireless parameter "running" read-only

### DIFF
--- a/changelogs/fragments/233-wireless-running-read-only.yml
+++ b/changelogs/fragments/233-wireless-running-read-only.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - api_info, api_modify - mark the ``interface wireless`` parameter ``running`` as read-only (https://github.com/ansible-collections/community.routeros/pull/233).

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -1563,7 +1563,7 @@ PATHS = {
                 'radio-name': KeyInfo(),
                 'rate-selection': KeyInfo(default='advanced'),
                 'rate-set': KeyInfo(default='default'),
-                'running': KeyInfo(default=False),
+                'running': KeyInfo(default=False, read_only=True),
                 'rx-chains': KeyInfo(default='0,1'),
                 'scan-list': KeyInfo(default='default'),
                 'secondary-frequency': KeyInfo(default=''),


### PR DESCRIPTION
##### SUMMARY

Commit e4a21311 added API data for the "interface wireless" path. It contained the read-only "running" parameter. Writing to the parameter fails:

```
Error while modifying for name="…" (ID *3): unknown parameter running
```

##### ISSUE TYPE
- Bugfix Pull Request
