### PR TITLE
Fixes #230: Add missing DoH parameters in the "ip dns" path

### DIFF
--- a/changelogs/fragments/235-add-missing-dns-attributes.yml
+++ b/changelogs/fragments/235-add-missing-dns-attributes.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - api_info, api_modify - add missing DoH parameters ``doh-max-concurrent-queries``, ``doh-max-server-connections``, and ``doh-timeout`` to the ``ip dns`` path (https://github.com/ansible-collections/community.routeros/issues/230, https://github.com/ansible-collections/community.routeros/pull/235)

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -1873,6 +1873,11 @@ PATHS = {
         unversioned=VersionedAPIData(
             single_value=True,
             fully_understood=True,
+            versioned_fields=[
+                ([('7.8', '>=')], 'doh-max-concurrent-queries', KeyInfo(default=50)),
+                ([('7.8', '>=')], 'doh-max-server-connections', KeyInfo(default=5)),
+                ([('7.8', '>=')], 'doh-timeout', KeyInfo(default='5s')),
+            ],
             fields={
                 'allow-remote-requests': KeyInfo(),
                 'cache-max-ttl': KeyInfo(default='1w'),


### PR DESCRIPTION
##### SUMMARY

- doh-max-concurrent-queries
- doh-max-server-connections
- doh-timeout

The parameters mentioned above seem to be added in version 7.8 as far as I could tell from the changelogs.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

- api_info
- api_modify

##### ADDITIONAL INFORMATION
