### PR TITLE
Add 'routing rule' path

### DIFF
--- a/changelogs/fragments/246-add-routing-rule-path.yml
+++ b/changelogs/fragments/246-add-routing-rule-path.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - api_info, api_modify - add ``routing rule`` path (https://github.com/ansible-collections/community.routeros/issues/162, https://github.com/ansible-collections/community.routeros/pull/246).

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -960,6 +960,24 @@ PATHS = {
             },
         ),
     ),
+    ('routing', 'rule'): APIData(
+        versioned=[
+            ('7', '>=', VersionedAPIData(
+                fully_understood=True,
+                fields={
+                    'action': KeyInfo(can_disable=True),
+                    'comment': KeyInfo(can_disable=True, remove_value=''),
+                    'disabled': KeyInfo(default=False),
+                    'dst-address': KeyInfo(can_disable=True),
+                    'interface': KeyInfo(can_disable=True),
+                    'min-prefix': KeyInfo(can_disable=True),
+                    'routing-mark': KeyInfo(can_disable=True),
+                    'src-address': KeyInfo(can_disable=True),
+                    'table': KeyInfo(can_disable=True),
+                },
+            )),
+        ],
+    ),
     ('routing', 'table'): APIData(
         versioned=[
             ('7', '>=', VersionedAPIData(

--- a/plugins/modules/api_info.py
+++ b/plugins/modules/api_info.py
@@ -185,6 +185,7 @@ options:
         - routing pimsm interface-template
         - routing rip
         - routing ripng
+        - routing rule
         - routing table
         - snmp
         - snmp community

--- a/plugins/modules/api_modify.py
+++ b/plugins/modules/api_modify.py
@@ -194,6 +194,7 @@ options:
         - routing pimsm interface-template
         - routing rip
         - routing ripng
+        - routing rule
         - routing table
         - snmp
         - snmp community


### PR DESCRIPTION
##### SUMMARY
Add the `routing rule` path for #162 .

In the issue the path `routing table` was requested but this was added with PR #215 . Somewhere in the depths of the MikroTik documentation I read that `routing table` would only make limited sense without `routing rule` but I cannot find it anymore.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- api_info
- api_modify

##### ADDITIONAL INFORMATION
None.