### PR TITLE
Changed primary key of 'tool netwatch'

### DIFF
--- a/changelogs/fragments/247-removed-primary-key-host-in-tool-netwatch.yml
+++ b/changelogs/fragments/247-removed-primary-key-host-in-tool-netwatch.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - api_info, api_modify - removed ``host`` primary key in ``tool netwatch`` path (https://github.com/ansible-collections/community.routeros/pull/248).

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -3652,7 +3652,6 @@ PATHS = {
         versioned=[
             ('7', '>=', VersionedAPIData(
                 fully_understood=True,
-                primary_keys=('host', ),
                 fields={
                     'certificate': KeyInfo(),
                     'check-certificate': KeyInfo(),

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -3652,7 +3652,7 @@ PATHS = {
         versioned=[
             ('7', '>=', VersionedAPIData(
                 fully_understood=True,
-                primary_keys=('name', ),
+                primary_keys=('host', ),
                 fields={
                     'certificate': KeyInfo(),
                     'check-certificate': KeyInfo(),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I've changed the primary key for `tool netwatch` from `name` to `host`, because `name` isn't used at all.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
When adding `name` to the playbook:
```
TASK [common : (routeros) Set netwatch] *********************************************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: KeyError: 'name'
fatal: [routeroshostname -> localhost]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/home/username/.ansible/tmp/ansible-tmp-1704395855.7240071-1606677-122124317821788/AnsiballZ_api_modify.py\", line 107, in <module>\n    _ansiballz_main()\n  File \"/home/username/.ansible/tmp/ansible-tmp-1704395855.7240071-1606677-122124317821788/AnsiballZ_api_modify.py\", line 99, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/home/username/.ansible/tmp/ansible-tmp-1704395855.7240071-1606677-122124317821788/AnsiballZ_api_modify.py\", line 47, in invoke_module\n    runpy.run_module(mod_name='ansible_collections.community.routeros.plugins.modules.api_modify', init_globals=dict(_module_fqn='ansible_collections.community.routeros.plugins.modules.api_modify', _modlib_path=modlib_path),\n  File \"<frozen runpy>\", line 226, in run_module\n  File \"<frozen runpy>\", line 98, in _run_module_code\n  File \"<frozen runpy>\", line 88, in _run_code\n  File \"/tmp/ansible_community.routeros.api_modify_payload_rbt_phd5/ansible_community.routeros.api_modify_payload.zip/ansible_collections/community/routeros/plugins/modules/api_modify.py\", line 1148, in <module>\n  File \"/tmp/ansible_community.routeros.api_modify_payload_rbt_phd5/ansible_community.routeros.api_modify_payload.zip/ansible_collections/community/routeros/plugins/modules/api_modify.py\", line 1144, in main\n  File \"/tmp/ansible_community.routeros.api_modify_payload_rbt_phd5/ansible_community.routeros.api_modify_payload.zip/ansible_collections/community/routeros/plugins/modules/api_modify.py\", line 870, in sync_with_primary_keys\n  File \"/tmp/ansible_community.routeros.api_modify_payload_rbt_phd5/ansible_community.routeros.api_modify_payload.zip/ansible_collections/community/routeros/plugins/modules/api_modify.py\", line 870, in <genexpr>\nKeyError: 'name'\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
```
When removing the `name`:
```
TASK [common : (routeros) Set netwatch] *********************************************************************************************************************************************
fatal: [routerhostname -> localhost]: FAILED! => {"changed": false, "msg": "Every element in data must contain \"name\". For example, the element at index #1 does not provide it."}
```


<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
