### PR TITLE
Change ip vrf for router OS v7

### DIFF
--- a/changelogs/fragments/259-add-routeros7-support-for-ip-vrf.yml
+++ b/changelogs/fragments/259-add-routeros7-support-for-ip-vrf.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - api_data - add support for the ``ip vrf`` path in RouterOS 7 and add support new primary_keys ``routing-mark`` for RouterOS 7 (https://github.com/ansible-collections/community.routeros/pull/259)
+  - api_modify, api_info - add support for the ``ip vrf`` path in RouterOS 7  (https://github.com/ansible-collections/community.routeros/pull/259)

--- a/changelogs/fragments/259-add-routeros7-support-for-ip-vrf.yml
+++ b/changelogs/fragments/259-add-routeros7-support-for-ip-vrf.yml
@@ -1,3 +1,2 @@
 minor_changes:
-  - api_data - add support for the ``ip vrf`` path in RouterOS 7 and add support new primary_keys ``routing-mark`` for RouterOS 7 (https://github.com/ansible-collections/community.routeros/pull/259)
   - api_modify, api_info - add support for the ``ip vrf`` path in RouterOS 7  (https://github.com/ansible-collections/community.routeros/pull/259)

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -728,16 +728,32 @@ PATHS = {
         ),
     ),
     ('ip', 'vrf'): APIData(
-        unversioned=VersionedAPIData(
-            fully_understood=True,
-            primary_keys=('name', ),
-            fields={
-                'comment': KeyInfo(can_disable=True, remove_value=''),
-                'disabled': KeyInfo(default=False),
-                'interfaces': KeyInfo(),
-                'name': KeyInfo(),
-            },
-        ),
+        versioned=[
+            ('7', '>=', VersionedAPIData(
+                fully_understood=True,
+                primary_keys=('name', ),
+                fields={
+                    'comment': KeyInfo(can_disable=True, remove_value=''),
+                    'disabled': KeyInfo(default=False),
+                    'interfaces': KeyInfo(),
+                    'name': KeyInfo(),
+                },
+            )),
+        ]
+    ),
+    ('ip', 'route', 'vrf'): APIData(
+        versioned=[
+            ('7', '<', VersionedAPIData(
+                fully_understood=True,
+                primary_keys=('routing-mark', ),
+                fields={
+                    'comment': KeyInfo(can_disable=True, remove_value=''),
+                    'disabled': KeyInfo(default=False),
+                    'interfaces': KeyInfo(),
+                    'routing-mark': KeyInfo(),
+                },
+            )),
+        ],
     ),
     ('ip', 'dhcp-server'): APIData(
         unversioned=VersionedAPIData(

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -727,15 +727,16 @@ PATHS = {
             },
         ),
     ),
-    ('ip', 'route', 'vrf'): APIData(
+    ('ip', 'vrf'): APIData(
         unversioned=VersionedAPIData(
             fully_understood=True,
-            primary_keys=('routing-mark', ),
+            primary_keys=('name', ),
             fields={
                 'comment': KeyInfo(can_disable=True, remove_value=''),
                 'disabled': KeyInfo(default=False),
                 'interfaces': KeyInfo(),
-                'routing-mark': KeyInfo(),
+                'name': KeyInfo(),
+                'numbers': KeyInfo(),
             },
         ),
     ),

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -736,7 +736,6 @@ PATHS = {
                 'disabled': KeyInfo(default=False),
                 'interfaces': KeyInfo(),
                 'name': KeyInfo(),
-                'numbers': KeyInfo(),
             },
         ),
     ),

--- a/plugins/modules/api_info.py
+++ b/plugins/modules/api_info.py
@@ -135,6 +135,7 @@ options:
         - ip pool
         - ip proxy
         - ip route
+        - ip route vrf
         - ip vrf
         - ip service
         - ip settings

--- a/plugins/modules/api_info.py
+++ b/plugins/modules/api_info.py
@@ -136,7 +136,6 @@ options:
         - ip proxy
         - ip route
         - ip route vrf
-        - ip vrf
         - ip service
         - ip settings
         - ip smb
@@ -148,6 +147,7 @@ options:
         - ip traffic-flow target
         - ip upnp
         - ip upnp interfaces
+        - ip vrf
         - ipv6 address
         - ipv6 dhcp-client
         - ipv6 dhcp-server

--- a/plugins/modules/api_info.py
+++ b/plugins/modules/api_info.py
@@ -135,7 +135,7 @@ options:
         - ip pool
         - ip proxy
         - ip route
-        - ip route vrf
+        - ip vrf
         - ip service
         - ip settings
         - ip smb

--- a/plugins/modules/api_modify.py
+++ b/plugins/modules/api_modify.py
@@ -144,7 +144,7 @@ options:
         - ip pool
         - ip proxy
         - ip route
-        - ip route vrf
+        - ip vrf
         - ip service
         - ip settings
         - ip smb

--- a/plugins/modules/api_modify.py
+++ b/plugins/modules/api_modify.py
@@ -144,6 +144,7 @@ options:
         - ip pool
         - ip proxy
         - ip route
+        - ip route vrf
         - ip vrf
         - ip service
         - ip settings

--- a/plugins/modules/api_modify.py
+++ b/plugins/modules/api_modify.py
@@ -145,7 +145,6 @@ options:
         - ip proxy
         - ip route
         - ip route vrf
-        - ip vrf
         - ip service
         - ip settings
         - ip smb
@@ -157,6 +156,7 @@ options:
         - ip traffic-flow target
         - ip upnp
         - ip upnp interfaces
+        - ip vrf
         - ipv6 address
         - ipv6 dhcp-client
         - ipv6 dhcp-server


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
In router OS 7, the path to vrf and the fields used have changed
tested on v7.13.3
```
