### PR TITLE
Fix date removal in nonverbose config

### DIFF
--- a/changelogs/fragments/262-fix-date-removal.yml
+++ b/changelogs/fragments/262-fix-date-removal.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - facts - fix date not getting removed for idempotent config export (https://github.com/ansible-collections/community.routeros/pull/262).

--- a/plugins/modules/facts.py
+++ b/plugins/modules/facts.py
@@ -311,7 +311,7 @@ class Config(FactsBase):
         '/export',
     ]
 
-    RM_DATE_RE = re.compile(r'^# [a-z0-9/][a-z0-9/]* [0-9:]* by RouterOS')
+    RM_DATE_RE = re.compile(r'^# [a-z0-9/-][a-z0-9/-]* [0-9:]* by RouterOS')
 
     def populate(self):
         super(Config, self).populate()


### PR DESCRIPTION
##### SUMMARY
As in newer versions of RouterOS the date format in the export is 2024-10-02 and no longer 2024/10/02, the regex to remove timestamps did no longer match all cases. This is fixed here.

##### CONTEXT
Documentation says that, the ansible_net_config_nonverbose fact is idempotent in the sense that if the facts module is run twice and the device’s config was not changed between the runs, the value is identical. This is achieved by running /export and stripping the timestamp from the comment in the first line.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
facts

##### ADDITIONAL INFORMATION
Date was successfully removed from export in RouterOS 7.9.* but not in 7.12.*