### PR TITLE
Remove default value for "running" field in "interface wireless"

### DIFF
--- a/changelogs/fragments/264-wireless-running-default.yml
+++ b/changelogs/fragments/264-wireless-running-default.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - api_info, api_modify - remove default value for read-only ``running`` field in ``interface wireless`` (https://github.com/ansible-collections/community.routeros/pull/264).

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -1932,7 +1932,7 @@ PATHS = {
                 'radio-name': KeyInfo(),
                 'rate-selection': KeyInfo(default='advanced'),
                 'rate-set': KeyInfo(default='default'),
-                'running': KeyInfo(default=False, read_only=True),
+                'running': KeyInfo(read_only=True),
                 'rx-chains': KeyInfo(default='0,1'),
                 'scan-list': KeyInfo(default='default'),
                 'secondary-frequency': KeyInfo(default=''),


### PR DESCRIPTION
##### SUMMARY
The `running` field can't be configured. By having a default value it's written and shows up in diffs.

##### ISSUE TYPE
- Bugfix Pull Request
