### PR TITLE
KeyInfo: prevent read_only usage with can_disable, remove_value, absent_value, default, or required

### DIFF
--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -199,6 +199,8 @@ class KeyInfo(object):
             raise ValueError('absent_value can not be combined with default, automatically_computed_from, can_disable=True, or absent_value')
         if read_only and write_only:
             raise ValueError('read_only and write_only cannot be used at the same time')
+        if read_only and any([can_disable, remove_value is not None, absent_value is not None, default is not None, required]):
+            raise ValueError('read_only can not be combined with can_disable, remove_value, absent_value, default, or required')
         self.can_disable = can_disable
         self.remove_value = remove_value
         self.automatically_computed_from = automatically_computed_from

--- a/tests/unit/plugins/module_utils/test__api_data.py
+++ b/tests/unit/plugins/module_utils/test__api_data.py
@@ -103,6 +103,10 @@ def test_key_info_errors():
         KeyInfo(read_only=True, write_only=True)
     assert exc.value.args[0] == 'read_only and write_only cannot be used at the same time'
 
+    with pytest.raises(ValueError) as exc:
+        KeyInfo(read_only=True, default=0)
+    assert exc.value.args[0] == 'read_only can not be combined with can_disable, remove_value, absent_value, default, or required'
+
 
 SPLIT_PATHS = [
     ('', [], ''),


### PR DESCRIPTION
##### SUMMARY
Ref: https://github.com/ansible-collections/community.routeros/pull/264#issuecomment-1975073650

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
_api_data.py
