### PR TITLE
Ignore pylint warnings for construct that does not work with Python 2

### DIFF
--- a/tests/sanity/ignore-2.17.txt
+++ b/tests/sanity/ignore-2.17.txt
@@ -1,1 +1,2 @@
 update-docs.py shebang
+tests/unit/compat/mock.py pylint:use-yield-from  # suggested construct does not work with Python 2

--- a/tests/unit/compat/mock.py
+++ b/tests/unit/compat/mock.py
@@ -51,7 +51,7 @@ if sys.version_info >= (3,) and sys.version_info < (3, 4, 4):
             # newline that our naive format() added
             data_as_list[-1] = data_as_list[-1][:-1]
 
-        for line in data_as_list:
+        for line in data_as_list:  # pylint: disable=use-yield-from
             yield line
 
     def mock_open(mock=None, read_data=''):
@@ -80,7 +80,7 @@ if sys.version_info >= (3,) and sys.version_info < (3, 4, 4):
             if handle.readline.return_value is not None:
                 while True:
                     yield handle.readline.return_value
-            for line in _data:
+            for line in _data:  # pylint: disable=use-yield-from
                 yield line
 
         global file_spec

--- a/tests/unit/compat/mock.py
+++ b/tests/unit/compat/mock.py
@@ -51,7 +51,7 @@ if sys.version_info >= (3,) and sys.version_info < (3, 4, 4):
             # newline that our naive format() added
             data_as_list[-1] = data_as_list[-1][:-1]
 
-        for line in data_as_list:  # pylint: disable=use-yield-from
+        for line in data_as_list:
             yield line
 
     def mock_open(mock=None, read_data=''):
@@ -80,7 +80,7 @@ if sys.version_info >= (3,) and sys.version_info < (3, 4, 4):
             if handle.readline.return_value is not None:
                 while True:
                     yield handle.readline.return_value
-            for line in _data:  # pylint: disable=use-yield-from
+            for line in _data:
                 yield line
 
         global file_spec


### PR DESCRIPTION
##### SUMMARY
Fixes nightly CI: https://github.com/ansible-collections/community.routeros/actions/runs/8399659133/job/23006035379

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
tests/unit/compat/mock.py
