### PR TITLE
Fix IPv6 address 'from-pool' default value

### DIFF
--- a/changelogs/fragments/270_fix_ipv6_from_pool_default_value.yml
+++ b/changelogs/fragments/270_fix_ipv6_from_pool_default_value.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - api_info, api_modify - add default value for ``from-pool`` field in ``/ipv6 address`` (https://github.com/ansible-collections/community.routeros/pull/270).

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -1397,7 +1397,7 @@ PATHS = {
                 'comment': KeyInfo(can_disable=True, remove_value=''),
                 'disabled': KeyInfo(default=False),
                 'eui-64': KeyInfo(default=False),
-                'from-pool': KeyInfo(),
+                'from-pool': KeyInfo(default=''),
                 'interface': KeyInfo(required=True),
                 'no-dad': KeyInfo(default=False),
             },


### PR DESCRIPTION
##### SUMMARY
When not set, the RouterOS API always returns the IPv6 Address 'from-pool' value as '', however _api_data.py has no default value set.

This PR fixes this issue.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
Test task:
```
  tasks:
    - name: Add IPv6 address with defaults
      community.routeros.api_modify:
        path: ipv6 address
        handle_absent_entries: remove
        handle_entries_content: remove
        data:
          - address: fedc:1234:5678:abcd::1/64
            interface: ether1
```

Output from api_info:
```
TASK [Print output of queue_simple_api_info] **************************************************************************************************************************************
ok: [testrtr1] => {
    "queue_simple_api_info": {
        "changed": false,
        "failed": false,
        "result": [
            {
                "!comment": null,
                ".id": "*9",
                "address": "fedc:1234:5678:abcd::1/64",
                "interface": "ether1"
            }
        ]
    }
}
```

Before change:
```
TASK [Add IPv6 address with defaults] *********************************************************************************************************************************************
--- before
+++ after
@@ -1,14 +1,8 @@
 {
     "data": [
         {
-            ".id": "*9",
             "address": "fedc:1234:5678:abcd::1/64",
-            "advertise": true,
-            "disabled": false,
-            "eui-64": false,
-            "from-pool": "",
-            "interface": "ether1",
-            "no-dad": false
+            "interface": "ether1"
         }
     ]
 }

changed: [testrtr1]
```

After change:
```
TASK [Add IPv6 address with defaults] *********************************************************************************************************************************************
ok: [testrtr1]
```