### PR TITLE
Add RouterOS 7.x support to '/mpls ldp' path

### DIFF
--- a/changelogs/fragments/271-mpls_ldp_routeros_7_support.yml
+++ b/changelogs/fragments/271-mpls_ldp_routeros_7_support.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - api_info, api_modify - Add RouterOS 7.x support to ``/mpls ldp`` path (https://github.com/ansible-collections/community.routeros/pull/271).

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -3605,15 +3605,20 @@ PATHS = {
         versioned=[
             ('7.1', '>=', VersionedAPIData(
                 fully_understood=True,
+                primary_keys=('vrf', ),
                 fields={
-                    'distribute-for-default-route': KeyInfo(default=False),
-                    'enabled': KeyInfo(default=False),
-                    'hop-limit': KeyInfo(default=255),
-                    'loop-detect': KeyInfo(default=False),
-                    'lsr-id': KeyInfo(default='0.0.0.0'),
-                    'path-vector-limit': KeyInfo(default=255),
-                    'transport-addresses': KeyInfo(default='0.0.0.0'),
-                    'use-explicit-null': KeyInfo(default=False),
+                    'afi': KeyInfo(can_disable=True),
+                    'distribute-for-default': KeyInfo(can_disable=True),
+                    'path-vector-limit': KeyInfo(can_disable=True),
+                    'vrf': KeyInfo(),
+                    'comment': KeyInfo(can_disable=True, remove_value=''),
+                    'hop-limit': KeyInfo(can_disable=True),
+                    'preferred-afi': KeyInfo(can_disable=True),
+                    'loop-detect': KeyInfo(can_disable=True),
+                    'transport-addresses': KeyInfo(can_disable=True),
+                    'disabled': KeyInfo(default=False),
+                    'lsr-id': KeyInfo(can_disable=True),
+                    'use-explicit-null': KeyInfo(can_disable=True),
                 },
             )),
             ('7.1', '<', VersionedAPIData(

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -3602,20 +3602,35 @@ PATHS = {
         ),
     ),
     ('mpls', 'ldp'): APIData(
-        unversioned=VersionedAPIData(
-            single_value=True,
-            fully_understood=True,
-            fields={
-                'distribute-for-default-route': KeyInfo(default=False),
-                'enabled': KeyInfo(default=False),
-                'hop-limit': KeyInfo(default=255),
-                'loop-detect': KeyInfo(default=False),
-                'lsr-id': KeyInfo(default='0.0.0.0'),
-                'path-vector-limit': KeyInfo(default=255),
-                'transport-address': KeyInfo(default='0.0.0.0'),
-                'use-explicit-null': KeyInfo(default=False),
-            },
-        ),
+        versioned=[
+            ('7.1', '>=', VersionedAPIData(
+                fully_understood=True,
+                fields={
+                    'distribute-for-default-route': KeyInfo(default=False),
+                    'enabled': KeyInfo(default=False),
+                    'hop-limit': KeyInfo(default=255),
+                    'loop-detect': KeyInfo(default=False),
+                    'lsr-id': KeyInfo(default='0.0.0.0'),
+                    'path-vector-limit': KeyInfo(default=255),
+                    'transport-addresses': KeyInfo(default='0.0.0.0'),
+                    'use-explicit-null': KeyInfo(default=False),
+                },
+            )),
+            ('7.1', '<', VersionedAPIData(
+                single_value=True,
+                fully_understood=True,
+                fields={
+                    'distribute-for-default-route': KeyInfo(default=False),
+                    'enabled': KeyInfo(default=False),
+                    'hop-limit': KeyInfo(default=255),
+                    'loop-detect': KeyInfo(default=False),
+                    'lsr-id': KeyInfo(default='0.0.0.0'),
+                    'path-vector-limit': KeyInfo(default=255),
+                    'transport-address': KeyInfo(default='0.0.0.0'),
+                    'use-explicit-null': KeyInfo(default=False),
+                },
+            )),
+        ],
     ),
     ('port', 'firmware'): APIData(
         unversioned=VersionedAPIData(


### PR DESCRIPTION
##### SUMMARY
RouterOS 7.1 completely re-writes the MPLS implementation (As per https://cdn.mikrotik.com/routeros/7.1/CHANGELOG), including support for multiple LDP instances.

This PR implements support for RouterOS 7.x LDP instances while retaining backwards compatibility with 6.x.

Some things to note:
- The 'vrf' value isn't required by the API, however as only one VRF is allowed per entry it seems sensible to consider this value s the primary key.
- As 'main' is the default VRF even when not defined, attempting to add an entry in the 'main' VRF while an entry with the VRF undefined is present will result in the error:
  ```Error while creating entry: failure: one active instance per VRF allowed```
- Whilst 'lsr-id' is able to be disabled, the router will not consider entries valid without it specified.  I've not set this as a required value, but I think perhaps it should be.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- api_info
- api_modify

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Test tasks:
```
  tasks:
    - name: Enable MPLS LDP instance on RouterOS 6.x
      when: "'routeros6' in group_names"
      community.routeros.api_modify:
        path: mpls ldp
        data:
          - enabled: true
            lsr-id: 1.2.3.4

    - name: Enable MPLS LDP instance on RouterOS 7.x
      when: "'routeros6' not in group_names"
      community.routeros.api_modify:
        path: mpls ldp
        handle_entries_content: remove_as_much_as_possible
        data:
          - vrf: main
            lsr-id: 1.2.3.4
```

Resulting data from api_info:

**RouterOS 6.49.10**
```
ok: [testrtr2] => {
    "queue_simple_api_info": {
        "changed": false,
        "failed": false,
        "result": [
            {
                "enabled": true,
                "lsr-id": "1.2.3.4"
            }
        ]
    }
}
```

**RouterOS 7.14.2**
```
ok: [testrtr1] => {
    "queue_simple_api_info": {
        "changed": false,
        "failed": false,
        "result": [
            {
                "!afi": null,
                "!comment": null,
                "!distribute-for-default": null,
                "!hop-limit": null,
                "!loop-detect": null,
                "!path-vector-limit": null,
                "!preferred-afi": null,
                "!transport-addresses": null,
                "!use-explicit-null": null,
                ".id": "*19",
                "lsr-id": "1.2.3.4",
                "vrf": "main"
            }
        ]
    }
}
```