### PR TITLE
Add support for '/interface pppoe-server server' path

### DIFF
--- a/changelogs/fragments/273-add_interface_pppoe-server_support.yml
+++ b/changelogs/fragments/273-add_interface_pppoe-server_support.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - api_info, api_modify - add missing path ``/interface pppoe-server server`` (https://github.com/ansible-collections/community.routeros/pull/273).

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -1497,6 +1497,28 @@ PATHS = {
             },
         ),
     ),
+    ('interface', 'pppoe-server', 'server'): APIData(
+        unversioned=VersionedAPIData(
+            fully_understood=True,
+            primary_keys=('interface', ),
+            fields={
+                'accept-empty-service': KeyInfo(default=True),
+                'authentication': KeyInfo(default='pap,chap,mschap1,mschap2'),
+                'comment': KeyInfo(can_disable=True, remove_value=''),
+                'default-profile': KeyInfo(default='default'),
+                'disabled': KeyInfo(default=True),
+                'interface': KeyInfo(required=True),
+                'keepalive-timeout': KeyInfo(default=10),
+                'max-mru': KeyInfo(default='auto'),
+                'max-mtu': KeyInfo(default='auto'),
+                'max-sessions': KeyInfo(default='unlimited'),
+                'mrru': KeyInfo(default='disabled'),
+                'one-session-per-host': KeyInfo(can_disable=True, remove_value=False),
+                'pado-delay': KeyInfo(default=0),
+                'service-name': KeyInfo(default=''),
+            },
+        ),
+    ),
     ('interface', 'pptp-server', 'server'): APIData(
         unversioned=VersionedAPIData(
             single_value=True,

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -1513,7 +1513,7 @@ PATHS = {
                 'max-mtu': KeyInfo(default='auto'),
                 'max-sessions': KeyInfo(default='unlimited'),
                 'mrru': KeyInfo(default='disabled'),
-                'one-session-per-host': KeyInfo(can_disable=True, remove_value=False),
+                'one-session-per-host': KeyInfo(default=False),
                 'pado-delay': KeyInfo(default=0),
                 'service-name': KeyInfo(default=''),
             },

--- a/plugins/modules/api_info.py
+++ b/plugins/modules/api_info.py
@@ -75,6 +75,7 @@ options:
         - interface ovpn-server server
         - interface ppp-client
         - interface pppoe-client
+        - interface pppoe-server server
         - interface pptp-server server
         - interface sstp-server server
         - interface vlan

--- a/plugins/modules/api_modify.py
+++ b/plugins/modules/api_modify.py
@@ -84,6 +84,7 @@ options:
         - interface ovpn-server server
         - interface ppp-client
         - interface pppoe-client
+        - interface pppoe-server server
         - interface pptp-server server
         - interface sstp-server server
         - interface vlan


### PR DESCRIPTION
##### SUMMARY
Add support for '/interface pppoe-server server' path.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- api_info
- api_modify

##### ADDITIONAL INFORMATION
Tested in RouterOS 6.49.10 and 7.14.2.

RouterOS 7.x supports two additional fields:
- accept-empty-service
- comment

Tasks used for testing:

**RouterOS 6.49.10**
```
  tasks:
    - name: Add interface pppoe-server server with defaults (RouterOS 6.x)
      when: "'routeros6' in group_names"
      community.routeros.api_modify:
        path: interface pppoe-server server
        handle_entries_content: remove
        data:
          - interface: ether1


    - name: Add interface pppoe-server server with all values set (RouterOS 6.x)
      when: "'routeros6' in group_names"
      community.routeros.api_modify:
        path: interface pppoe-server server
        handle_entries_content: remove
        data:
          - interface: ether2
#            accept-empty-service: false
            authentication: pap,chap
#            comment: Test PPPoE Server
            default-profile: default-encryption
            disabled: false
            keepalive-timeout: 30
            max-mru: 1500
            max-mtu: 1500
            max-sessions: 10
            mrru: 1500
            one-session-per-host: true
            pado-delay: 100
            service-name: 'test_pppoe_server'
```

**RouterOS 7.14.2**
```
  tasks:
    - name: Add interface pppoe-server server with defaults (RouterOS 7.x)
      when: "'routeros6' not in group_names"
      community.routeros.api_modify:
        path: interface pppoe-server server
        handle_entries_content: remove
        data:
          - interface: ether1


    - name: Add interface pppoe-server server with all values set (RouterOS 7.x)
      when: "'routeros6' not in group_names"
      community.routeros.api_modify:
        path: interface pppoe-server server
        handle_entries_content: remove
        data:
          - interface: ether2
            accept-empty-service: false
            authentication: pap,chap
            comment: Test PPPoE Server
            default-profile: default-encryption
            disabled: false
            keepalive-timeout: 30
            max-mru: 1500
            max-mtu: 1500
            max-sessions: 10
            mrru: 1500
            one-session-per-host: true
            pado-delay: 100
            service-name: 'test_pppoe_server'
```

Resulting api_info output:

**RouterOS 6.49.10**
```
### Only defaults
{
    "!accept-empty-service": null,
    "!comment": null,
    ".id": "*4",
    "interface": "ether1"
},

### All values changed
{
    "!accept-empty-service": null,
    "!comment": null,
    ".id": "*5",
    "authentication": "pap,chap",
    "default-profile": "default-encryption",
    "disabled": false,
    "interface": "ether2",
    "keepalive-timeout": 30,
    "max-mru": 1500,
    "max-mtu": 1500,
    "max-sessions": 10,
    "mrru": 1500,
    "one-session-per-host": true,
    "pado-delay": 100,
    "service-name": "test_pppoe_server"
}
```

**RouterOS 7.14.2**
```
### Only defaults
{
    "!accept-empty-service": null,
    "!comment": null,
    ".id": "*4",
    "interface": "ether1"
},

### All values changed
{
    ".id": "*5",
    "accept-empty-service": false,
    "authentication": "pap,chap",
    "comment": "Test PPPoE Server",
    "default-profile": "default-encryption",
    "disabled": false,
    "interface": "ether2",
    "keepalive-timeout": 30,
    "max-mru": 1500,
    "max-mtu": 1500,
    "max-sessions": 10,
    "mrru": 1500,
    "one-session-per-host": true,
    "pado-delay": 100,
    "service-name": "test_pppoe_server"
}
```