### PR TITLE
EE tests: stop building EE with RHEL UBI 8

### DIFF
--- a/.github/workflows/ee.yml
+++ b/.github/workflows/ee.yml
@@ -62,14 +62,6 @@ jobs:
             ansible_runner: ansible-runner
             base_image: quay.io/centos/centos:stream9
             pre_base: '"#"'
-          - name: ansible-core 2.13 @ RHEL UBI 8
-            ansible_core: https://github.com/ansible/ansible/archive/stable-2.13.tar.gz
-            ansible_runner: ansible-runner
-            other_deps: |2
-                python_interpreter:
-                  package_system: python39 python39-pip python39-wheel python39-cryptography
-            base_image: docker.io/redhat/ubi8:latest
-            pre_base: '"#"'
     runs-on: ubuntu-latest
     steps:
       - name: Check out code


### PR DESCRIPTION
##### SUMMARY
Apparently the pip is too old to be able to handle two requirements for netaddr (`netaddr` and `netaddr>=0.10.1`) in the same requirements.txt file...

See https://github.com/ansible-collections/community.routeros/actions/runs/9608694669/job/26503096454

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
EE CI
