### PR TITLE
Add parameter `host-key-type` for `ip ssh` path

### DIFF
--- a/changelogs/fragments/297-add-ip-ssh-host-key-type.yml
+++ b/changelogs/fragments/297-add-ip-ssh-host-key-type.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - api_info, api_modify - add parameter ``host-key-type`` for ``ip ssh`` path (https://github.com/ansible-collections/community.routeros/issues/280, https://github.com/ansible-collections/community.routeros/pull/297).

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -3205,6 +3205,9 @@ PATHS = {
         unversioned=VersionedAPIData(
             single_value=True,
             fully_understood=True,
+            versioned_fields=[
+                ([('7.9', '>=')], 'host-key-type', KeyInfo(default='rsa')),
+            ],
             fields={
                 'allow-none-crypto': KeyInfo(default=False),
                 'always-allow-password-login': KeyInfo(default=False),


### PR DESCRIPTION
##### SUMMARY
Add parameter `host-key-type` for the `ip ssh` path.

Fixes #280.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- api_info
- api_modify

##### ADDITIONAL INFORMATION
None