### PR TITLE
Support name and is-responder properties on Wireguard peers

### DIFF
--- a/changelogs/fragments/304-wireguard-name-responder.yml
+++ b/changelogs/fragments/304-wireguard-name-responder.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - api_info, api_modify - add support for the ``name`` and ``is-responder`` properties under the ``interface wireguard peers`` path introduced in RouterOS 7.15 (https://github.com/ansible-collections/community.routeros/pull/304).

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -2340,6 +2340,10 @@ PATHS = {
                 'preshared-key': KeyInfo(can_disable=True, remove_value=''),
                 'public-key': KeyInfo(),
             },
+            versioned_fields=[
+                ([('7.15', '>=')], 'name', KeyInfo()),
+                ([('7.15', '>=')], 'is-responder', KeyInfo()),
+            ],
         ),
     ),
     ('interface', 'wireless'): APIData(


### PR DESCRIPTION
##### SUMMARY

From the RouterOS 7.15 changelog:

```
*) wireguard - added option to mark peer as responder only;
*) wireguard - added peer "name" field and display it in logs;
```

##### ISSUE TYPE
- Feature Pull Request
