### PR TITLE
api_info/api_modify: path /interface bridge [port]: fix default of ingress-filtering for ROS < 7

### DIFF
--- a/changelogs/fragments/306-ingress-filtering-ros6.yml
+++ b/changelogs/fragments/306-ingress-filtering-ros6.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "api_modify, api_info - change the default of ``ingress-filtering`` in paths ``interface bridge`` and ``interface bridge port`` back to ``false`` for RouterOS before version 7 (https://github.com/ansible-collections/community.routeros/pull/305)."

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -259,6 +259,10 @@ PATHS = {
         unversioned=VersionedAPIData(
             fully_understood=True,
             primary_keys=('name', ),
+            versioned_fields=[
+                ([('7.0', '<')], 'ingress-filtering', KeyInfo(default=False)),
+                ([('7.0', '>=')], 'ingress-filtering', KeyInfo(default=True)),
+            ],
             fields={
                 'admin-mac': KeyInfo(default=''),
                 'ageing-time': KeyInfo(default='5m'),
@@ -273,7 +277,6 @@ PATHS = {
                 'frame-types': KeyInfo(default='admit-all'),
                 'forward-delay': KeyInfo(default='15s'),
                 'igmp-snooping': KeyInfo(default=False),
-                'ingress-filtering': KeyInfo(default=True),
                 'max-message-age': KeyInfo(default='20s'),
                 'mtu': KeyInfo(default='auto'),
                 'name': KeyInfo(),
@@ -1310,6 +1313,10 @@ PATHS = {
         unversioned=VersionedAPIData(
             fully_understood=True,
             primary_keys=('interface', ),
+            versioned_fields=[
+                ([('7.0', '<')], 'ingress-filtering', KeyInfo(default=False)),
+                ([('7.0', '>=')], 'ingress-filtering', KeyInfo(default=True)),
+            ],
             fields={
                 'auto-isolate': KeyInfo(default=False),
                 'bpdu-guard': KeyInfo(default=False),
@@ -1322,7 +1329,6 @@ PATHS = {
                 'frame-types': KeyInfo(default='admit-all'),
                 'horizon': KeyInfo(default='none'),
                 'hw': KeyInfo(default=True),
-                'ingress-filtering': KeyInfo(default=True),
                 'interface': KeyInfo(),
                 'internal-path-cost': KeyInfo(default=10),
                 'learn': KeyInfo(default='auto'),


### PR DESCRIPTION
##### SUMMARY
The default only changed to `true` for ROS 7.

Ref: #125.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
api_info
api_modify
