### PR TITLE
Support DHCP matching type added in RouterOS 7.16

### DIFF
--- a/changelogs/fragments/321-dhcp-server-matcher-matching-type.yml
+++ b/changelogs/fragments/321-dhcp-server-matcher-matching-type.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - api_info, api_modify - add support for the ``matching-type`` property in ``ip dhcp-server matcher`` introduced by RouterOS 7.16 (https://github.com/ansible-collections/community.routeros/pull/321).

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -2798,6 +2798,9 @@ PATHS = {
             ('7.4', '>=', VersionedAPIData(
                 fully_understood=True,
                 primary_keys=('name', ),
+                versioned_fields=[
+                    ([('7.16', '>=')], 'matching-type', KeyInfo()),
+                ],
                 fields={
                     'address-pool': KeyInfo(default='none'),
                     'code': KeyInfo(required=True),


### PR DESCRIPTION
##### SUMMARY
Support DHCP matching type added in RouterOS 7.16.

##### ISSUE TYPE
- Feature Pull Request
