### PR TITLE
fix: add missing fields to `ip pool` path

### DIFF
--- a/changelogs/fragments/327-add-missing-ip-pool-fields.yml
+++ b/changelogs/fragments/327-add-missing-ip-pool-fields.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - api_info, api_modify - add missing fields ``comment``, ``copy-from``, ``next-pool`` to ``ip pool`` path (https://github.com/ansible-collections/community.routeros/pull/327).
+  - api_info, api_modify - add missing fields ``comment``, ``next-pool`` to ``ip pool`` path (https://github.com/ansible-collections/community.routeros/pull/327).

--- a/changelogs/fragments/327-add-missing-ip-pool-fields.yml
+++ b/changelogs/fragments/327-add-missing-ip-pool-fields.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - api_info, api_modify - add missing fields ``comment``, ``copy-from``, ``next-pool`` to ``ip pool`` path (https://github.com/ansible-collections/community.routeros/pull/327).

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -709,7 +709,6 @@ PATHS = {
             primary_keys=('name', ),
             fields={
                 'comment': KeyInfo(),
-                'copy-from': KeyInfo(),
                 'name': KeyInfo(),
                 'next-pool': KeyInfo(),
                 'ranges': KeyInfo(),

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -708,7 +708,10 @@ PATHS = {
             fully_understood=True,
             primary_keys=('name', ),
             fields={
+                'comment': KeyInfo(),
+                'copy-from': KeyInfo(),
                 'name': KeyInfo(),
+                'next-pool': KeyInfo(),
                 'ranges': KeyInfo(),
             },
         ),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
add missing fields `comment`, `copy-from`, `next-pool` to `ip pool` path.
Not sure in what version if routeros they were introduced, the oldest I have access to is 6.46 and they are present there.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`api_info`
`api_modify`
`ip pool`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
