### PR TITLE
Add 'idempotent' attribute

### DIFF
--- a/plugins/doc_fragments/attributes.py
+++ b/plugins/doc_fragments/attributes.py
@@ -23,7 +23,7 @@ attributes:
     support: N/A
   idempotent:
     description:
-      - When run twice in a row with the same arguments, the second invocation indicates no change.
+      - When run twice in a row outside check mode, with the same arguments, the second invocation indicates no change.
       - This assumes that the system controlled/queried by the module has not changed in a relevant way.
 """
 

--- a/plugins/doc_fragments/attributes.py
+++ b/plugins/doc_fragments/attributes.py
@@ -21,6 +21,20 @@ attributes:
   platform:
     description: Target OS/families that can be operated against.
     support: N/A
+  idempotent:
+    description:
+      - When run twice in a row with the same arguments, the second invocation indicates no change.
+      - This assumes that the system controlled/queried by the module has not changed in a relevant way.
+"""
+
+    # Should be used together with the standard fragment
+    IDEMPOTENT_NOT_MODIFY_STATE = r"""
+options: {}
+attributes:
+  idempotent:
+    support: full
+    details:
+      - This action does not modify state.
 """
 
     # Should be used together with the standard fragment

--- a/plugins/modules/api.py
+++ b/plugins/modules/api.py
@@ -33,6 +33,10 @@ attributes:
     platforms: RouterOS
   action_group:
     version_added: 2.1.0
+  idempotent:
+    support: N/A
+    details:
+      - Whether the executed command is idempotent depends on the operation performed.
 options:
   path:
     description:

--- a/plugins/modules/api_facts.py
+++ b/plugins/modules/api_facts.py
@@ -29,6 +29,7 @@ extends_documentation_fragment:
   - community.routeros.attributes.actiongroup_api
   - community.routeros.attributes.facts
   - community.routeros.attributes.facts_module
+  - community.routeros.attributes.idempotent_not_modify_state
 attributes:
   platform:
     support: full

--- a/plugins/modules/api_find_and_modify.py
+++ b/plugins/modules/api_find_and_modify.py
@@ -35,6 +35,8 @@ attributes:
   platform:
     support: full
     platforms: RouterOS
+  idempotent:
+    support: full
 options:
   path:
     description:

--- a/plugins/modules/api_info.py
+++ b/plugins/modules/api_info.py
@@ -28,6 +28,7 @@ extends_documentation_fragment:
   - community.routeros.api.restrict
   - community.routeros.attributes
   - community.routeros.attributes.actiongroup_api
+  - community.routeros.attributes.idempotent_not_modify_state
   - community.routeros.attributes.info_module
 attributes:
   platform:

--- a/plugins/modules/api_modify.py
+++ b/plugins/modules/api_modify.py
@@ -42,6 +42,8 @@ attributes:
   platform:
     support: full
     platforms: RouterOS
+  idempotent:
+    support: full
 options:
   path:
     description:

--- a/plugins/modules/command.py
+++ b/plugins/modules/command.py
@@ -29,6 +29,10 @@ attributes:
   platform:
     support: full
     platforms: RouterOS
+  idempotent:
+    support: N/A
+    details:
+      - Whether the executed command is idempotent depends on the command.
 options:
   commands:
     description:

--- a/plugins/modules/facts.py
+++ b/plugins/modules/facts.py
@@ -19,6 +19,7 @@ extends_documentation_fragment:
   - community.routeros.attributes
   - community.routeros.attributes.facts
   - community.routeros.attributes.facts_module
+  - community.routeros.attributes.idempotent_not_modify_state
 attributes:
   platform:
     support: full


### PR DESCRIPTION
##### SUMMARY
Adds a new attribute `idempotent` for module documentation, which states whether (resp. under which circumstances) the module is idempotent.

Related PRs:
- https://github.com/ansible-collections/community.dns/pull/238
- https://github.com/ansible-collections/community.crypto/pull/833
- https://github.com/ansible-collections/community.docker/pull/1022
- https://github.com/ansible-collections/community.hrobot/pull/132
- https://github.com/ansible-collections/community.sops/pull/217

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
module documentation
