### PR TITLE
Fixes #338: Add require-message-auth in radius path

### DIFF
--- a/changelogs/fragments/339-add-require-message-auth-for-radius.yml
+++ b/changelogs/fragments/339-add-require-message-auth-for-radius.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - api_info, api_modify - Add missing attribute ``require-message-auth`` for the ``radius`` path which exists since RouterOS version 7.15 (https://github.com/ansible-collections/community.routeros/issues/338, https://github.com/ansible-collections/community.routeros/pull/339).
+  - api_info, api_modify - add missing attribute ``require-message-auth`` for the ``radius`` path which exists since RouterOS version 7.15 (https://github.com/ansible-collections/community.routeros/issues/338, https://github.com/ansible-collections/community.routeros/pull/339).

--- a/changelogs/fragments/339-add-require-message-auth-for-radius.yml
+++ b/changelogs/fragments/339-add-require-message-auth-for-radius.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - api_info, api_modify - Add missing attribute ``require-message-auth`` for the ``radius`` path which exists since RouterOS version 7.15 (https://github.com/ansible-collections/community.routeros/issues/338, https://github.com/ansible-collections/community.routeros/pull/339).

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -4018,6 +4018,9 @@ PATHS = {
                 'src-address': KeyInfo(default='0.0.0.0'),
                 'timeout': KeyInfo(default='300ms'),
             },
+            versioned_fields=[
+                ([('7.15', '>=')], 'require-message-auth', KeyInfo(default='yes-for-request-resp')),
+            ],
         ),
     ),
     ('radius', 'incoming'): APIData(


### PR DESCRIPTION
##### SUMMARY
Fixes #338 by adding the attribute "require-message-auth" (which was added in RouterOS version 7.15) to the "radius" path.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- _api_data.py

##### ADDITIONAL INFORMATION

