### PR TITLE
DHCPv6 client: add missing 'use-interface-duid' option

### DIFF
--- a/changelogs/fragments/341-add-dhcpv6-client-use-interface-duid.yml
+++ b/changelogs/fragments/341-add-dhcpv6-client-use-interface-duid.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - api_info, api_modify - add the ``use-interface-duid`` option for ``ipv6 dhcp-client`` path. This option prevents issues with Fritzbox modems and routers, when using virtual interfaces (like VLANs) may create duplicated records in hosts config, this breaks original "expose-host" function. Also add the ``script``, ``custom-duid`` and ``validate-server-duid`` as backport from 7.15 version update (https://github.com/ansible-collections/community.routeros/pull/341).

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -3544,6 +3544,14 @@ PATHS = {
                 'request': KeyInfo(),
                 'use-peer-dns': KeyInfo(default=True),
             },
+            versioned_fields=[
+                # Mikrotik does not provide exact version in official changelogs.
+                # The 7.15 version is the earliest, found option in router config backups:
+                ([('7.15', '>=')], 'script', KeyInfo(default='')),
+                ([('7.15', '>=')], 'custom-duid', KeyInfo(default='')),
+                ([('7.15', '>=')], 'use-interface-duid', KeyInfo(default=False)),
+                ([('7.15', '>=')], 'validate-server-duid', KeyInfo(default=True)),
+            ],
         ),
     ),
     ('ipv6', 'dhcp-server'): APIData(


### PR DESCRIPTION
##### SUMMARY
api_info, api_modify: add the ``use-interface-duid`` option for DHCPv6 client. 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
api_info, api_modify

##### ADDITIONAL INFORMATION
This option prevents issues with Fritzbox modems and routers, when using virtual interfaces (like VLANs) may create duplicated records in hosts config, this breaks original "expose-host" function.

The ``use-interface-duid`` corrects this behavior: the DUID for link-local address and DHCPv6 request are the same, and user can configure per-host option in Fritzbox OS as expected.

Tested on current ``7.17`` and ``7.16.2`` versions:

```diff
--- before
+++ after
@@ -12,6 +12,7 @@
             "pool-prefix-length": 64,
             "prefix-hint": "::/59",
             "request": "address,prefix",
+            "use-interface-duid": true,
             "use-peer-dns": false
         }
     ]
```