### PR TITLE
Add 'interface 6to4' path, allows manage 6to4 tunnels like HE

### DIFF
--- a/changelogs/fragments/342-add-interface-6to4.yml
+++ b/changelogs/fragments/342-add-interface-6to4.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - api_info, api_modify - add the ``interface 6to4`` path. Used to manage IPv6 tunnels via tunnel-brokers like HE, where native IPv6 is not provided (https://github.com/ansible-collections/community.routeros/pull/342).

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -226,6 +226,25 @@ def join_path(path):
 # 3. All bold attributes go into the `primary_keys` list -- this is not always true!
 
 PATHS = {
+    ('interface', '6to4'): APIData(
+        unversioned=VersionedAPIData(
+            fully_understood=True,
+            primary_keys=('name', ),
+            fields={
+                'clamp-tcp-mss': KeyInfo(default=True),
+                'comment': KeyInfo(can_disable=True, remove_value=''),
+                'disabled': KeyInfo(default=False),
+                'dont-fragment': KeyInfo(default=False),
+                'dscp': KeyInfo(default='inherit'),
+                'ipsec-secret': KeyInfo(can_disable=True),
+                'keepalive': KeyInfo(default='10s,10', can_disable=True),
+                'local-address': KeyInfo(default='0.0.0.0'),
+                'mtu': KeyInfo(default='auto'),
+                'name': KeyInfo(),
+                'remote-address': KeyInfo(required=True),
+            }
+        ),
+    ),
     ('interface', 'bonding'): APIData(
         unversioned=VersionedAPIData(
             fully_understood=True,

--- a/plugins/modules/api_info.py
+++ b/plugins/modules/api_info.py
@@ -53,6 +53,7 @@ options:
       - caps-man provisioning
       - caps-man security
       - certificate settings
+      - interface 6to4
       - interface bonding
       - interface bridge
       - interface bridge mlag

--- a/plugins/modules/api_modify.py
+++ b/plugins/modules/api_modify.py
@@ -64,6 +64,7 @@ options:
       - caps-man provisioning
       - caps-man security
       - certificate settings
+      - interface 6to4
       - interface bonding
       - interface bridge
       - interface bridge mlag


### PR DESCRIPTION
##### SUMMARY
Add 'interface 6to4' path, allows manage 6to4 tunnels like HE

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- api_info, api_modify

##### ADDITIONAL INFORMATION
Add the ``interface 6to4`` path. 

Used to manage ipv6 tunnels via tunnel-brokers like HE, where native ipv6 is not provided.

[Mikrotik documentation related to 6to4](https://help.mikrotik.com/docs/spaces/ROS/pages/135004174/6to4)