### PR TITLE
Change default for ddns-enabled to "auto" for RouterOS 7.17 and newer

### DIFF
--- a/changelogs/fragments/350-ip-cloud-ddns-enabled-auto.yml
+++ b/changelogs/fragments/350-ip-cloud-ddns-enabled-auto.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - api_info, api_modify - change default for ``/ip/cloud/ddns-enabled`` for RouterOS 7.17 and newer from ``yes`` to ``auto`` (https://github.com/ansible-collections/community.routeros/pull/350).

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -2777,8 +2777,11 @@ PATHS = {
         unversioned=VersionedAPIData(
             single_value=True,
             fully_understood=True,
+            versioned_fields=[
+                ([('7.17', '<')], 'ddns-enabled', KeyInfo(default=False)),
+                ([('7.17', '>=')], 'ddns-enabled', KeyInfo(default='auto')),
+            ],
             fields={
-                'ddns-enabled': KeyInfo(default=False),
                 'ddns-update-interval': KeyInfo(default='none'),
                 'update-time': KeyInfo(default=True),
             },


### PR DESCRIPTION
##### SUMMARY

From the RouterOS 7.17 changelog:

> *) cloud - changed ddns-enabled setting from "no" to "auto" (service
> is enabled when BTH is enabled);

`no` is not supported anymore, only `yes` and `auto` are.

##### ISSUE TYPE
- Bugfix Pull Request