### PR TITLE
Add "mdns-repeat-ifaces" field to "ip dns"

### DIFF
--- a/changelogs/fragments/358-mdns-repeat-ifaces.yml
+++ b/changelogs/fragments/358-mdns-repeat-ifaces.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - api_info, api_modify - add ``mdns-repeat-ifaces`` to ``ip dns`` for RouterOS 7.16 and newer (https://github.com/ansible-collections/community.routeros/pull/358).

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -2967,6 +2967,7 @@ PATHS = {
                 ([('7.8', '>=')], 'doh-max-concurrent-queries', KeyInfo(default=50)),
                 ([('7.8', '>=')], 'doh-max-server-connections', KeyInfo(default=5)),
                 ([('7.8', '>=')], 'doh-timeout', KeyInfo(default='5s')),
+                ([('7.16', '>=')], 'mdns-repeat-ifaces', KeyInfo()),
             ],
             fields={
                 'allow-remote-requests': KeyInfo(),


### PR DESCRIPTION
##### SUMMARY
RouterOS 7.16 introduced an mDNS proxy, configurable via `mdns-repeat-ifaces` under `/ip/dns`.

##### ISSUE TYPE
- Feature Pull Request
