### PR TITLE
Field name change in 'routing bgp connection' (from 'address-families' to 'afi')

### DIFF
--- a/changelogs/fragments/360-bgp-connection-afi.yml
+++ b/changelogs/fragments/360-bgp-connection-afi.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - api_modify - field name change in ``routing bgp connection`` path implemented by RouterOS 7.19 and newer (https://github.com/ansible-collections/community.routeros/pull/360).
+  - api_modify, api_info - field name change in ``routing bgp connection`` path implemented by RouterOS 7.19 and newer (https://github.com/ansible-collections/community.routeros/pull/360).

--- a/changelogs/fragments/360-bgp-connection-afi.yml
+++ b/changelogs/fragments/360-bgp-connection-afi.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - api_modify - field name change in ``routing bgp connection`` path implemented by RouterOS 7.19 and newer (https://github.com/ansible-collections/community.routeros/pull/360).

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -4982,10 +4982,13 @@ PATHS = {
     ('routing', 'bgp', 'connection'): APIData(
         unversioned=VersionedAPIData(
             fully_understood=True,
+            versioned_fields=[
+                ([('7.19', '<')], 'address-families', KeyInfo()),
+                ([('7.19', '>=')], 'afi', KeyInfo()),
+            ],
             fields={
                 'as': KeyInfo(),
                 'add-path-out': KeyInfo(),
-                'address-families': KeyInfo(),
                 'cisco-vpls-nlri-len-fmt': KeyInfo(),
                 'cluster-id': KeyInfo(),
                 'comment': KeyInfo(),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Field name change in 'routing bgp connection' (from 'address-families' to 'afi')

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
