### PR TITLE
Rename Wireguard peer "is-responder" to "responder" for RouterOS 7.17

### DIFF
--- a/changelogs/fragments/364-wireguard-responder.yml
+++ b/changelogs/fragments/364-wireguard-responder.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - api_info, api_modify - rename ``is-responder`` property in ``interface wireguard peers`` to ``responder`` for RouterOS 7.17 and newer (https://github.com/ansible-collections/community.routeros/pull/364).

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -2441,7 +2441,8 @@ PATHS = {
             },
             versioned_fields=[
                 ([('7.15', '>=')], 'name', KeyInfo()),
-                ([('7.15', '>=')], 'is-responder', KeyInfo()),
+                ([('7.15', '>='), ('7.17', '<')], 'is-responder', KeyInfo()),
+                ([('7.17', '>=')], 'responder', KeyInfo()),
             ],
         ),
     ),


### PR DESCRIPTION
##### SUMMARY
RouterOS 7.17 renamed the `is-responder` property in `/interface/wireguard/peers` to `responder`.

##### ISSUE TYPE
- Bugfix Pull Request
