### PR TITLE
Update _api_data.py

### DIFF
--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -281,6 +281,7 @@ PATHS = {
             versioned_fields=[
                 ([('7.0', '<')], 'ingress-filtering', KeyInfo(default=False)),
                 ([('7.0', '>=')], 'ingress-filtering', KeyInfo(default=True)),
+                ([('7.13', '>=')], 'port-cost-mode', KeyInfo(default='long')),
                 ([('7.16', '>=')], 'forward-reserved-addresses', KeyInfo(default=False)),
                 ([('7.16', '>=')], 'max-learned-entries', KeyInfo(default='auto')),
             ],


### PR DESCRIPTION
Add /interface/bridge property "port-cost-mode" which is supported since RouterOS 7.13.

See changelog for details: https://mikrotik.com/download/changelogs

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add /interface/bridge property "port-cost-mode" which is supported since RouterOS 7.13.

See changelog for details: https://mikrotik.com/download/changelogs



##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

