### PR TITLE
Update logging action fields for ROS 7.18

### DIFF
--- a/changelogs/fragments/381-logging-cef.yml
+++ b/changelogs/fragments/381-logging-cef.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - api_info, api modify - add ``remote-log-format`` and ``remote-protocol`` and ``event-delimiter`` to ``system logging action`` (https://github.com/ansible-collections/community.routeros/pull/381)

--- a/changelogs/fragments/381-logging-cef.yml
+++ b/changelogs/fragments/381-logging-cef.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - api_info, api modify - add ``remote-log-format`` and ``remote-protocol`` and ``event-delimiter`` to ``system logging action`` (https://github.com/ansible-collections/community.routeros/pull/381)
+  - api_info, api modify - add ``remote-log-format``, ``remote-protocol``, and ``event-delimiter`` to ``system logging action`` (https://github.com/ansible-collections/community.routeros/pull/381).

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -5212,6 +5212,11 @@ PATHS = {
         unversioned=VersionedAPIData(
             fully_understood=True,
             primary_keys=('name',),
+            versioned_fields=[
+                ([('7.18', '>=')], 'remote-log-format', KeyInfo(default='default')),
+                ([('7.18', '>=')], 'remote-protocol', KeyInfo(default='udp')),
+                ([('7.18', '>=')], 'cef-event-delimiter', KeyInfo(default='\r\n')),
+            ],
             fields={
                 'bsd-syslog': KeyInfo(default=False),
                 'comment': KeyInfo(can_disable=True, remove_value=''),


### PR DESCRIPTION
##### SUMMARY
Add fields to /system/logging/action to support new CEF related fields

From ROS 7.18 changelogs:

*) log - added CEF format support for remote logging;
*) log - added option to select TCP or UDP for remote logging;