### PR TITLE
Set mangle passthrough default for RouterOS 7.19

### DIFF
--- a/changelogs/fragments/382-mangle-passthrough.yml
+++ b/changelogs/fragments/382-mangle-passthrough.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - api_info, api_modify - set ``passthrough`` default in ``ip firewall mangle`` to ``true`` for RouterOS 7.19 and newer (https://github.com/ansible-collections/community.routeros/pull/382).

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -3145,6 +3145,10 @@ PATHS = {
         unversioned=VersionedAPIData(
             fully_understood=True,
             stratify_keys=('chain', ),
+            versioned_fields=[
+                ([('7.19', '<')], 'passthrough', KeyInfo(can_disable=True)),
+                ([('7.19', '>=')], 'passthrough', KeyInfo(default=True)),
+            ],
             fields={
                 'action': KeyInfo(),
                 'address-list': KeyInfo(can_disable=True),
@@ -3196,7 +3200,6 @@ PATHS = {
                 'p2p': KeyInfo(can_disable=True),
                 'packet-mark': KeyInfo(can_disable=True),
                 'packet-size': KeyInfo(can_disable=True),
-                'passthrough': KeyInfo(can_disable=True),
                 'per-connection-classifier': KeyInfo(can_disable=True),
                 'port': KeyInfo(can_disable=True),
                 'priority': KeyInfo(can_disable=True),


### PR DESCRIPTION
##### SUMMARY

The behaviour of the `passthrough` property in `ip/firewall/mangle` has changed in RouterOS 7.19:

```
*) firewall - always show "passthrough" when exporting mangle table;
```

Per the documentation at [1] the default is `true`.

[1] https://help.mikrotik.com/docs/spaces/ROS/pages/48660587/Mangle
