### PR TITLE
fix: Fix pattern to handle long system identity names

### DIFF
--- a/plugins/terminal/routeros.py
+++ b/plugins/terminal/routeros.py
@@ -31,7 +31,9 @@ class TerminalModule(TerminalBase):
 
     terminal_stdout_re = [
         re.compile(br"\x1b<"),
-        re.compile(br"\[[\w\-\.]+\@[\w\s\-\.\/]+\] ?(<SAFE)?> ?$"),
+        re.compile(
+            br"((\[[\w\-\.]+\@)|(\r\<(([\w\-\.]*\@)|)))"
+            br"[\w\s\-\.\/]+\] ?(<SAFE)?> ?$"),
         re.compile(br"Please press \"Enter\" to continue!"),
         re.compile(br"Do you want to see the software license\? \[Y\/n\]: ?"),
     ]


### PR DESCRIPTION

##### SUMMARY
When the system identity string is too long, the terminal output may be truncated. The truncated output is marked by multiple carriage returns (`\r`) and a `<` symbol.

The existing regex failed to match these truncated prompts.
This update introduces a more flexible regex that matches both truncated and preserved output.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
terminal

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->

When the System identity is set to a long enough string, the output buffer will be truncated. As a result, the task will fail raising the error 'command timeout triggered, timeout value is 30 secs.'.

By analyzing the logs, it's possible to notice that the truncated output aways starts with a sequence carriage returns (`\r`) followed by a less than (`<`) symbol and the truncated end part of the prompt, as in the following example:

```py
b'\r\n\r\r\r\r<MY_VERYVERY-LONG-SYSTEM-IDENTIY-NAME] > '
```

The solution was to change the first part of the regex, `\[[\w\-\.]+\@`  adding the fallback `(\r\<(([\w\-\.]*\@)|))`, so the output must start with either `[user@` or `<`. The rest of the original pattern `[\w\s\-\.\/]+\] ?(<SAFE)?> ?$` will ensure that the output is, indeed, a prompt.

The final pattern is:
`((\[[\w\-\.]+\@)|(\r\<(([\w\-\.]*\@)|)))[\w\s\-\.\/]+\] ?(<SAFE)?> ?$")`

Matching output:
```py
# Preserved output
b'\r\n\r\r\r\r<[myself@SYSTEM-IDENTIY-NAME] > '
# Truncated outputs
b'\r\n\r\r\r\r<myself@VERY-LONG-SYSTEM-IDENTIY-NAME] > '
b'\r\n\r\r\r\r<@A_VERYVERY-LONG-SYSTEM-IDENTIY-NAME] > '
b'\r\n\r\r\r\r<MY_VERYVERY-LONG-SYSTEM-IDENTIY-NAME] > '
```

Not matching output:
```py
# Starts with '[' but doesn't contains '<user>@'
b'[SYSTEM-IDENTIY-NAME] > '
# Starts with '['  and contains '@' but doesn't contains '<user>'
b'[@SYSTEM-IDENTIY-NAME] > '
# Doesn't ends with the pattern '\] ?(<SAFE)?> ?$'
b'\r\n\r\r\r\r<MY_VERYVERY-LONG-SYSTEM-IDENTIY-NAME > '
```

