### PR TITLE
Handle IP addresses configured on disappeared interfaces

### DIFF
--- a/changelogs/fragments/391-report-unknown-interfaces.yml
+++ b/changelogs/fragments/391-report-unknown-interfaces.yml
@@ -1,0 +1,12 @@
+---
+bugfixes:
+  - |
+    api_facts - also report interfaces that are inferred only by reference by IP addresses.
+    RouterOS's APIs have IPv4 and IPv6 addresses point at interfaces by their name, which can
+    change over time and in-between API calls, such that interfaces may have been enumerated
+    under another name, or not at all (i.e. when removed). Such interfaces are now reported
+    under their new or temporary name and with a synthetic ``type`` property set to differentiate
+    the more likely and positively confirmed removal case (with ``type: "ansible:unknown"``) from
+    the unlikely and probably transient naming mismatch (with ``type: "ansible:mismatch"``).
+    Previously, api_facts would have crashed with a `KeyError` exception.
+    (https://github.com/ansible-collections/community.routeros/pull/391).

--- a/changelogs/fragments/391-report-unknown-interfaces.yml
+++ b/changelogs/fragments/391-report-unknown-interfaces.yml
@@ -4,9 +4,9 @@ bugfixes:
     api_facts - also report interfaces that are inferred only by reference by IP addresses.
     RouterOS's APIs have IPv4 and IPv6 addresses point at interfaces by their name, which can
     change over time and in-between API calls, such that interfaces may have been enumerated
-    under another name, or not at all (i.e. when removed). Such interfaces are now reported
+    under another name, or not at all (for example when removed). Such interfaces are now reported
     under their new or temporary name and with a synthetic ``type`` property set to differentiate
     the more likely and positively confirmed removal case (with ``type: "ansible:unknown"``) from
     the unlikely and probably transient naming mismatch (with ``type: "ansible:mismatch"``).
-    Previously, api_facts would have crashed with a `KeyError` exception.
+    Previously, the api_facts module would have crashed with a ``KeyError`` exception
     (https://github.com/ansible-collections/community.routeros/pull/391).

--- a/plugins/modules/api_facts.py
+++ b/plugins/modules/api_facts.py
@@ -317,7 +317,9 @@ class Interfaces(FactsBase):
     def populate_addresses(self, data, family):
         for value in data:
             key = value['interface']
-            iface = self.facts['interfaces'].setdefault(key, {"type": "unknown"} if key.startswith('*') else {})
+            iface = self.facts['interfaces'].setdefault(key, (
+                {"type": "ansible:unknown"} if key.startswith('*') else
+                {"type": "ansible:mismatch"}))
             iface_addrs = iface.setdefault(family, [])
             addr, subnet = value['address'].split('/')
             subnet = subnet.strip()

--- a/plugins/modules/api_facts.py
+++ b/plugins/modules/api_facts.py
@@ -317,8 +317,8 @@ class Interfaces(FactsBase):
     def populate_addresses(self, data, family):
         for value in data:
             key = value['interface']
-            if family not in self.facts['interfaces'][key]:
-                self.facts['interfaces'][key][family] = []
+            iface = self.facts['interfaces'].setdefault(key, {"type": "unknown"} if key.startswith('*') else {})
+            iface_addrs = iface.setdefault(family, [])
             addr, subnet = value['address'].split('/')
             subnet = subnet.strip()
             # Try to convert subnet to an integer
@@ -328,7 +328,7 @@ class Interfaces(FactsBase):
                 pass
             ip = dict(address=addr.strip(), subnet=subnet)
             self.add_ip_address(addr.strip(), family)
-            self.facts['interfaces'][key][family].append(ip)
+            iface_addrs.append(ip)
 
     def add_ip_address(self, address, family):
         if family == 'ipv4':


### PR DESCRIPTION
##### SUMMARY
When an IP address had been configured on an interface that has since then disappeared (e.g. a tunnel interface was deleted) or was not discovered for other reasons, api_facts.py fails with KeyError because no pre-allocated dict is found under that interface name.

Note: missing interfaces on addresses are reported by the raw `.id` that previously identified the interface. The CLI represents this as `*id` (.e.g. `*23`), and in WinBox the interface name is shown as "unknown".

But issue #86 also reports cases where interfaces are not enumerated for other reasons despite them to exist.

This change collects these addresses nevertheless, leaving all interface properties undefined. For interfaces which RouterOS reports as unlinked, the device `"type": "unknown"` is also set, e.g.:

```
        "ansible_net_interfaces": {
            "*2E": {
                "ipv4": [
                    {
                        "address": "192.0.2.1",
                        "subnet": 24
                    }
                ],
                "type": "unknown"
            },
```

Fixes #86

##### ISSUE TYPE
- Bugfix Pull Request