### PR TITLE
Set default value for interface list include/exclude

### DIFF
--- a/changelogs/fragments/394-iface-list-defaults.yml
+++ b/changelogs/fragments/394-iface-list-defaults.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - api_info, api_modify - set default value for ``include`` and ``exclude`` properties in ``system note`` to an empty string (https://github.com/ansible-collections/community.routeros/pull/394).

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -441,8 +441,8 @@ PATHS = {
             fully_understood=True,
             fields={
                 'comment': KeyInfo(can_disable=True, remove_value=''),
-                'exclude': KeyInfo(),
-                'include': KeyInfo(),
+                'exclude': KeyInfo(default=''),
+                'include': KeyInfo(default=''),
                 'name': KeyInfo(),
             },
         ),

--- a/tests/unit/plugins/modules/test_api_info.py
+++ b/tests/unit/plugins/modules/test_api_info.py
@@ -470,8 +470,6 @@ class TestRouterosApiInfoModule(ModuleTestCase):
             {
                 '.id': '*2000010',
                 'name': 'WAN',
-                'include': '',
-                'exclude': '',
                 'comment': 'defconf',
             },
         ])
@@ -523,24 +521,18 @@ class TestRouterosApiInfoModule(ModuleTestCase):
             {
                 '.id': '*2000000',
                 'name': 'all',
-                'include': '',
-                'exclude': '',
                 'builtin': True,
                 'comment': 'contains all interfaces',
             },
             {
                 '.id': '*2000001',
                 'name': 'none',
-                'include': '',
-                'exclude': '',
                 'builtin': True,
                 'comment': 'contains no interfaces',
             },
             {
                 '.id': '*2000010',
                 'name': 'WAN',
-                'include': '',
-                'exclude': '',
                 'builtin': False,
                 'comment': 'defconf',
             },


### PR DESCRIPTION
##### SUMMARY
Without a default value a pre-existing value isn't removed unless the caller specifies the property.

##### ISSUE TYPE
- Bugfix Pull Request
