### PR TITLE
api_find_and_modify and api_modify: compare values as strings

### DIFF
--- a/changelogs/fragments/397-compare-by-value.yml
+++ b/changelogs/fragments/397-compare-by-value.yml
@@ -1,0 +1,6 @@
+minor_changes:
+  - "api_find_and_modify, api_modify - instead of comparing supplied values as-is to values retrieved from the API and converted to some types (int, bool) by librouteros,
+     instead compare values by converting them to strings first, using similar conversion rules that librouteros uses
+     (https://github.com/ansible-collections/community.routeros/issues/389, https://github.com/ansible-collections/community.routeros/issues/370,
+     https://github.com/ansible-collections/community.routeros/issues/325, https://github.com/ansible-collections/community.routeros/issues/169,
+     https://github.com/ansible-collections/community.routeros/pull/397)."

--- a/plugins/modules/api_find_and_modify.py
+++ b/plugins/modules/api_find_and_modify.py
@@ -195,6 +195,10 @@ from ansible_collections.community.routeros.plugins.module_utils._api_data impor
     split_path,
 )
 
+from ansible_collections.community.routeros.plugins.module_utils._api_helper import (
+    value_to_str,
+)
+
 try:
     from librouteros.exceptions import LibRouterosError
 except Exception:
@@ -285,7 +289,7 @@ def main():
             current_value = entry.get(key)
             if key in DISABLED_MEANS_EMPTY_STRING and value == '' and current_value is None:
                 current_value = value
-            if current_value != value:
+            if value_to_str(current_value) != value_to_str(value):
                 matches = False
                 break
         if matches:
@@ -312,7 +316,7 @@ def main():
             current_value = entry.get(key)
             if key in DISABLED_MEANS_EMPTY_STRING and value == '' and current_value is None:
                 current_value = value
-            if current_value != value:
+            if value_to_str(current_value) != value_to_str(value):
                 if value is None:
                     disable_key = '!%s' % key
                     if key in DISABLED_MEANS_EMPTY_STRING:

--- a/tests/unit/plugins/module_utils/test__api_helper.py
+++ b/tests/unit/plugins/module_utils/test__api_helper.py
@@ -17,7 +17,7 @@ from ansible_collections.community.routeros.plugins.module_utils._api_data impor
 )
 
 from ansible_collections.community.routeros.plugins.module_utils._api_helper import (
-    _value_to_str,
+    value_to_str,
     _test_rule_except_invert,
     validate_and_prepare_restrict,
     restrict_entry_accepted,
@@ -25,23 +25,33 @@ from ansible_collections.community.routeros.plugins.module_utils._api_helper imp
 
 
 VALUE_TO_STR = [
-    (None, None),
-    ('', u''),
-    ('foo', u'foo'),
-    (True, u'true'),
-    (False, u'false'),
-    ([], u'[]'),
-    ({}, u'{}'),
-    (1, u'1'),
-    (-42, u'-42'),
-    (1.5, u'1.5'),
-    (1.0, u'1.0'),
+    (None, u'', {'none_to_empty': True}),
+    (None, None, {'none_to_empty': False}),
+    (None, None, {}),
+    ('', u'', {}),
+    ('foo', u'foo', {}),
+    (True, u'true', {'compat_bool': True}),
+    (False, u'false', {'compat_bool': True}),
+    (True, u'yes', {'compat_bool': False}),
+    (False, u'no', {'compat_bool': False}),
+    (True, u'yes', {}),
+    (False, u'no', {}),
+    ('true', u'true', {}),
+    ('false', u'false', {}),
+    ('yes', u'yes', {}),
+    ('no', u'no', {}),
+    ([], u'[]', {}),
+    ({}, u'{}', {}),
+    (1, u'1', {}),
+    (-42, u'-42', {}),
+    (1.5, u'1.5', {}),
+    (1.0, u'1.0', {}),
 ]
 
 
-@pytest.mark.parametrize("value, expected", VALUE_TO_STR)
-def test_value_to_str(value, expected):
-    result = _value_to_str(value)
+@pytest.mark.parametrize("value, expected, kwargs", VALUE_TO_STR)
+def test_value_to_str(value, expected, kwargs):
+    result = value_to_str(value, **kwargs)
     print(repr(result))
     assert result == expected
 
@@ -123,7 +133,7 @@ TEST_RULE_EXCEPT_INVERT = [
 
 @pytest.mark.parametrize("value, rule, expected", TEST_RULE_EXCEPT_INVERT)
 def test_rule_except_invert(value, rule, expected):
-    result = _test_rule_except_invert(value, rule)
+    result = _test_rule_except_invert(value, rule, compat=True)
     print(repr(result))
     assert result == expected
 

--- a/tests/unit/plugins/modules/test_api_find_and_modify.py
+++ b/tests/unit/plugins/modules/test_api_find_and_modify.py
@@ -407,6 +407,54 @@ class TestRouterosApiFindAndModifyModule(ModuleTestCase):
         self.assertEqual(result['modify_count'], 0)
 
     @patch('ansible_collections.community.routeros.plugins.modules.api_find_and_modify.compose_api_path',
+           new=create_fake_path(('ip', 'service'), START_IP_SERVICE, read_only=True))
+    def test_idempotent_3(self):
+        with self.assertRaises(AnsibleExitJson) as exc:
+            args = self.config_module_args.copy()
+            args.update({
+                'path': 'ip service',
+                'find': {
+                    'name': 'api',
+                },
+                'values': {
+                    'port': '8728',
+                },
+            })
+            with set_module_args(args):
+                self.module.main()
+
+        result = exc.exception.args[0]
+        self.assertEqual(result['changed'], False)
+        self.assertEqual(result['old_data'], START_IP_SERVICE_OLD_DATA)
+        self.assertEqual(result['new_data'], START_IP_SERVICE_OLD_DATA)
+        self.assertEqual(result['match_count'], 1)
+        self.assertEqual(result['modify_count'], 0)
+
+    @patch('ansible_collections.community.routeros.plugins.modules.api_find_and_modify.compose_api_path',
+           new=create_fake_path(('ip', 'service'), START_IP_SERVICE, read_only=True))
+    def test_idempotent_4(self):
+        with self.assertRaises(AnsibleExitJson) as exc:
+            args = self.config_module_args.copy()
+            args.update({
+                'path': 'ip service',
+                'find': {
+                    'port': '8728',
+                },
+                'values': {
+                    'name': 'api',
+                },
+            })
+            with set_module_args(args):
+                self.module.main()
+
+        result = exc.exception.args[0]
+        self.assertEqual(result['changed'], False)
+        self.assertEqual(result['old_data'], START_IP_SERVICE_OLD_DATA)
+        self.assertEqual(result['new_data'], START_IP_SERVICE_OLD_DATA)
+        self.assertEqual(result['match_count'], 1)
+        self.assertEqual(result['modify_count'], 0)
+
+    @patch('ansible_collections.community.routeros.plugins.modules.api_find_and_modify.compose_api_path',
            new=create_fake_path(('ip', 'dns', 'static'), START_IP_DNS_STATIC))
     def test_change(self):
         with self.assertRaises(AnsibleExitJson) as exc:


### PR DESCRIPTION
##### SUMMARY
While the API only knows strings, librouteros converts some strings like `yes` and `no` and everything that looks like an integer to a boolean resp. integer, and vice versa when setting values.

This leads to problems when users provide values in the wrong type (say a string `"yes"` instead of `true`, or a string `"1"` instead of the integer `1`). Jinja evaluation in ansible-core < 2.19 didn't help here either, since it sometimes coerces values to strings that were originally integers.

This PR tries to prevent this by doing all comparisons with strings, by using the same conversion rules as librouteros.

Likely
- fixes #332
- fixes #370
- fixes #325
- fixes #169
(and maybe more?)

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
api_find_and_modify
api_modify
