### PR TITLE
Add support for VRF to API 'system/logging/action' from v7.19

### DIFF
--- a/changelogs/fragments/401-vrf-logging.yml
+++ b/changelogs/fragments/401-vrf-logging.yml
@@ -1,3 +1,3 @@
 minor_changes:
-  - "api_modify - add ``VRF`` for ``system logging action`` with a default of ``main`` for RouterOS 7.19 and newer
+  - "api_modify - add ``vrf`` for ``system logging action`` with a default of ``main`` for RouterOS 7.19 and newer
      (https://github.com/ansible-collections/community.routeros/pull/401)."

--- a/changelogs/fragments/401-vrf-logging.yml
+++ b/changelogs/fragments/401-vrf-logging.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - "api_modify - add ``VRF`` for ``system logging action`` with a default of ``main`` for RouterOS 7.19 and newer
+     (https://github.com/ansible-collections/community.routeros/pull/401)."

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -5251,6 +5251,7 @@ PATHS = {
                 ([('7.18', '>=')], 'remote-log-format', KeyInfo(default='default')),
                 ([('7.18', '>=')], 'remote-protocol', KeyInfo(default='udp')),
                 ([('7.18', '>=')], 'cef-event-delimiter', KeyInfo(default='\r\n')),
+                ([('7.19', '>=')], 'vrf', KeyInfo(default='main')),
             ],
             fields={
                 'bsd-syslog': KeyInfo(default=False),

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -5251,7 +5251,7 @@ PATHS = {
                 ([('7.18', '>=')], 'remote-log-format', KeyInfo(default='default')),
                 ([('7.18', '>=')], 'remote-protocol', KeyInfo(default='udp')),
                 ([('7.18', '>=')], 'cef-event-delimiter', KeyInfo(default='\r\n')),
-                ([('7.19', '>=')], 'vrf', KeyInfo(default='main')),
+                ([('7.19.6', '>=')], 'vrf', KeyInfo(default='main')),
             ],
             fields={
                 'bsd-syslog': KeyInfo(default=False),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
From release [7.19.6](https://mikrotik.com/download/changelogs#c-stable-v7_19_6) it is now possible to set a VRF for the `system/logging/action`
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
('system', 'logging', 'action')

##### Before / After
```
      - name: remote
        remote: 127.0.0.1
        remote-log-format: syslog
        remote-port: 514
        remote-protocol: udp
        src-address: 0.0.0.0
        syslog-facility: daemon
        syslog-severity: auto
        syslog-time-format: bsd-syslog
        target: remote
        vrf: vrf_test
      encoding: ASCII
      ensure_order: false
      force_no_cert: false
      handle_absent_entries: remove
      handle_entries_content: remove_as_much_as_possible
      handle_read_only: error
      handle_write_only: create_only
      hostname: <redacted>
      password: VALUE_SPECIFIED_IN_NO_LOG_PARAMETER
      path: system logging action
      port: null
      restrict: null
      timeout: 10
      tls: false
      username: <redacted>
      validate_cert_hostname: false
      validate_certs: true
     msg: Unknown key "vrf" for name="remote".

---

  new_data:
  - .id: '*3'
    name: remote
    remote: 127.0.0.1
    remote-log-format: syslog
    remote-port: 514
    remote-protocol: udp
    src-address: 0.0.0.0
    syslog-facility: daemon
    syslog-severity: auto
    syslog-time-format: bsd-syslog
    target: remote
    vrf: vrf_test
  old_data:
  - .id: '*3'
    name: remote
    remote: 127.0.0.1
    remote-log-format: syslog
    remote-port: 514
    remote-protocol: udp
    src-address: 0.0.0.0
    syslog-facility: daemon
    syslog-severity: auto
    syslog-time-format: bsd-syslog
    target: remote
    vrf: main
```