### PR TITLE
support for field `new-priority` in API path `ipv6 fiewall mangle`

### DIFF
--- a/changelogs/fragments/402-ipv6-firewall-mangle-new-priority.yml
+++ b/changelogs/fragments/402-ipv6-firewall-mangle-new-priority.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - api_modify, api_info - support for field ``new-priority`` in API path ``ipv6 firewall mangle```
+    (https://github.com/ansible-collections/community.routeros/pull/402).

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -3785,6 +3785,7 @@ PATHS = {
                 'new-hop-limit': KeyInfo(),
                 'new-mss': KeyInfo(),
                 'new-packet-mark': KeyInfo(),
+                'new-priority': KeyInfo(can_disable=True),
                 'new-routing-mark': KeyInfo(),
                 'nth': KeyInfo(can_disable=True),
                 'out-bridge-port': KeyInfo(can_disable=True),


### PR DESCRIPTION
support for field `new-priority` in API path `ipv6 fiewall mangle`

##### SUMMARY
adding the `new-priority` filed that was missing

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
api_modify, api_info

##### ADDITIONAL INFORMATION
none

