### PR TITLE
field `instance` in ``routing bgp connection`` path is required and `router-id` has been moved to `routing bgp instance` by RouterOS 7.20 and newer

### DIFF
--- a/changelogs/fragments/404-bgp-connection-instance.yml
+++ b/changelogs/fragments/404-bgp-connection-instance.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - api_modify, api_info - field `instance` in ``routing bgp connection`` path is required and `router-id` has been moved to `routing bgp instance` by RouterOS 7.20 and newer (https://github.com/ansible-collections/community.routeros/pull/404).

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -5066,6 +5066,8 @@ PATHS = {
             versioned_fields=[
                 ([('7.19', '<')], 'address-families', KeyInfo()),
                 ([('7.19', '>=')], 'afi', KeyInfo()),
+                ([('7.20', '<')], 'router-id', KeyInfo()),
+                ([('7.20', '>=')], 'instance', KeyInfo(required=True)),
             ],
             fields={
                 'as': KeyInfo(),


### PR DESCRIPTION
…router-id` has been moved to `routing bgp instance` by RouterOS 7.20 and newer

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
