### PR TITLE
Avoid six

### DIFF
--- a/changelogs/fragments/405-six.yml
+++ b/changelogs/fragments/405-six.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Avoid using ``ansible.module_utils.six`` to avoid deprecation warnings with ansible-core 2.20 (https://github.com/ansible-collections/community.routeros/pull/405)."

--- a/plugins/modules/api_facts.py
+++ b/plugins/modules/api_facts.py
@@ -177,7 +177,6 @@ ansible_facts:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six import iteritems
 from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.routeros.plugins.module_utils.api import (
@@ -311,7 +310,7 @@ class Interfaces(FactsBase):
             self.facts['neighbors'] = list(self.parse_detail(data))
 
     def populate_interfaces(self, data):
-        for key, value in iteritems(data):
+        for key, value in data.items():
             self.facts['interfaces'][key] = value
 
     def populate_addresses(self, data, family):
@@ -408,7 +407,7 @@ class Routing(FactsBase):
         return facts
 
     def populate_result(self, name, data):
-        for key, value in iteritems(data):
+        for key, value in data.items():
             self.facts[name][key] = value
 
 
@@ -481,7 +480,7 @@ def main():
         facts.update(inst.facts)
 
     ansible_facts = {}
-    for key, value in iteritems(facts):
+    for key, value in facts.items():
         key = 'ansible_net_%s' % key
         ansible_facts[key] = value
 

--- a/plugins/modules/command.py
+++ b/plugins/modules/command.py
@@ -121,13 +121,18 @@ failed_conditions:
   sample: ['...', '...']
 """
 
+import sys
 import time
 
 from ansible_collections.community.routeros.plugins.module_utils.routeros import run_commands
 from ansible_collections.community.routeros.plugins.module_utils.routeros import routeros_argument_spec
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.parsing import Conditional
-from ansible.module_utils.six import string_types
+
+if sys.version_info[0] == 2:
+    string_types = (str, unicode)  # noqa: F821, pylint: disable=undefined-variable
+else:
+    string_types = (bytes, str)
 
 
 def to_lines(stdout):

--- a/plugins/modules/facts.py
+++ b/plugins/modules/facts.py
@@ -182,7 +182,6 @@ import re
 from ansible_collections.community.routeros.plugins.module_utils.routeros import run_commands
 from ansible_collections.community.routeros.plugins.module_utils.routeros import routeros_argument_spec
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six import iteritems
 
 
 class FactsBase(object):
@@ -364,7 +363,7 @@ class Interfaces(FactsBase):
             self.facts['neighbors'] = list(self.parse_detail(data))
 
     def populate_interfaces(self, data):
-        for key, value in iteritems(data):
+        for key, value in data.items():
             self.facts['interfaces'][key] = value
 
     def populate_addresses(self, data, family):
@@ -555,27 +554,27 @@ class Routing(FactsBase):
         return facts
 
     def populate_bgp_peer(self, data):
-        for key, value in iteritems(data):
+        for key, value in data.items():
             self.facts['bgp_peer'][key] = value
 
     def populate_vpnv4_route(self, data):
-        for key, value in iteritems(data):
+        for key, value in data.items():
             self.facts['bgp_vpnv4_route'][key] = value
 
     def populate_bgp_instance(self, data):
-        for key, value in iteritems(data):
+        for key, value in data.items():
             self.facts['bgp_instance'][key] = value
 
     def populate_route(self, data):
-        for key, value in iteritems(data):
+        for key, value in data.items():
             self.facts['route'][key] = value
 
     def populate_ospf_instance(self, data):
-        for key, value in iteritems(data):
+        for key, value in data.items():
             self.facts['ospf_instance'][key] = value
 
     def populate_ospf_neighbor(self, data):
-        for key, value in iteritems(data):
+        for key, value in data.items():
             self.facts['ospf_neighbor'][key] = value
 
 
@@ -647,7 +646,7 @@ def main():
         facts.update(inst.facts)
 
     ansible_facts = dict()
-    for key, value in iteritems(facts):
+    for key, value in facts.items():
         key = 'ansible_net_%s' % key
         ansible_facts[key] = value
 

--- a/tests/sanity/ignore-2.20.txt
+++ b/tests/sanity/ignore-2.20.txt
@@ -1,4 +1,1 @@
-plugins/modules/api_facts.py pylint:ansible-bad-import-from
-plugins/modules/command.py pylint:ansible-bad-import-from
-plugins/modules/facts.py pylint:ansible-bad-import-from
 tests/update-docs.py shebang


### PR DESCRIPTION
##### SUMMARY
ansible.module_utils.six is deprecated in ansible-core 2.20.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
various
