### PR TITLE
add `primary_keys=('name',)` to path `container` for RouterOS >= 7.19

### DIFF
--- a/changelogs/fragments/444-fix-container-paths-name-parameter.yml
+++ b/changelogs/fragments/444-fix-container-paths-name-parameter.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - api_info, api_modify - add ``primary_keys=('name',)`` to the ``container`` path for RouterOS >=7.19 (https://github.com/ansible-collections/community.routeros/issues/443, https://github.com/ansible-collections/community.routeros/pull/444).

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -845,8 +845,6 @@ PATHS = {
                     'workdir': KeyInfo(),
                 },
             )),
-        ],
-        versioned=[
             ('7.15', '>=', VersionedAPIData(
                 fully_understood=True,
                 fields={


### PR DESCRIPTION
##### SUMMARY
Adds `primary_keys=('name',)` to the `container` path for RouterOS versions 7.19 and later.

Fixes #443 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- _api_data.py

##### ADDITIONAL INFORMATION
Before RouterOS 7.19, the `name` parameter was a read-only field that was automatically generated when creating a container.
Starting with version 7.19, it is possible to assign and modify a container’s name manually.
Although RouterOS can still auto-generate this parameter, it must remain unique.
To ensure correct handling when modifying an existing container, `name` is now declared as a `primary_key` in the `api_modify` module for RouterOS versions `>= 7.19`.