### PR TITLE
api_modify: recommend librouteros 3.4.2 or newer when using certain paths

### DIFF
--- a/plugins/modules/api_modify.py
+++ b/plugins/modules/api_modify.py
@@ -27,6 +27,9 @@ notes:
   - If write-only fields are present in the path, the module is B(not idempotent) in a strict sense, since it is not able
     to verify the current value of these fields. The behavior the module should assume can be controlled with the O(handle_write_only)
     option.
+  - If you want to modify a path where a property is called V(cmd), you should use librouteros 3.4.2 or newer.
+    This is for example true for O(path=container).
+    Previous versions of librouteros had a bug preventing to add or modify entries when V(cmd) is provided.
 requirements:
   - Needs L(ordereddict,https://pypi.org/project/ordereddict) for Python 2.6
 extends_documentation_fragment:


### PR DESCRIPTION
##### SUMMARY
Fixes #442.

While we could also work around this bug with extra code, I think it's better to simply ask users to upgrade their librouteros.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
api_modify
