### PR TITLE
Add RouterOS 7.21 advertise-dns=self support for ipv6 nd

### DIFF
--- a/changelogs/fragments/ipv6-nd-advertise-dns-self.yml
+++ b/changelogs/fragments/ipv6-nd-advertise-dns-self.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - api_info, api_modify - add support for ``advertise-dns=self`` in the ``ipv6 nd`` path for RouterOS >= 7.21.

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -9385,10 +9385,11 @@ PATHS = {
                 ([('7.15', '>=')], 'comment', KeyInfo()),
                 # ([('7.15', '>=')], 'copy-from', KeyInfo(write_only=True)),
                 ([('7.15', '>=')], 'numbers', KeyInfo(read_only=True)),
+                ([('7.21', '<')], 'advertise-dns', KeyInfo(default=True)),
+                ([('7.21', '>=')], 'advertise-dns', KeyInfo(default='yes')),
                 ([('7.15', '>=')], 'pref64', KeyInfo()),
             ],
             fields={
-                'advertise-dns': KeyInfo(default=True),
                 'advertise-mac-address': KeyInfo(default=True),
                 'disabled': KeyInfo(default=False),
                 'dns': KeyInfo(default=''),

--- a/tests/unit/plugins/module_utils/test__api_data.py
+++ b/tests/unit/plugins/module_utils/test__api_data.py
@@ -124,6 +124,25 @@ def test_key_info_errors():
     assert exc.value.args[0] == 'read_only can not be combined with can_disable, remove_value, absent_value, default, or required'
 
 
+def test_ipv6_nd_advertise_dns_is_boolean_before_routeros_7_21():
+    versioned_path_info = PATHS[('ipv6', 'nd')]
+    versioned_path_info.provide_version('7.20.0')
+    path_info = versioned_path_info.get_data()
+
+    field = path_info.fields['advertise-dns']
+    assert field.default is True
+
+
+def test_ipv6_nd_advertise_dns_accepts_routeros_enum_values_from_7_21():
+    versioned_path_info = PATHS[('ipv6', 'nd')]
+    versioned_path_info.provide_version('7.21.0')
+    path_info = versioned_path_info.get_data()
+
+    field = path_info.fields['advertise-dns']
+    assert field.default == 'yes'
+    assert {field.default, 'no', 'self'} == {'yes', 'no', 'self'}
+
+
 SPLIT_PATHS = [
     ('', [], ''),
     ('  ip  ', ['ip'], 'ip'),

--- a/tests/unit/plugins/modules/test_api_modify.py
+++ b/tests/unit/plugins/modules/test_api_modify.py
@@ -101,6 +101,29 @@ START_IP_ADDRESS = [
 
 START_IP_ADDRESS_OLD_DATA = massage_expected_result_data(START_IP_ADDRESS, ('ip', 'address'))
 
+START_IPV6_ND = [
+    {
+        '.id': '*1',
+        'interface': 'bridge-yes',
+        'advertise-dns': 'yes',
+        'disabled': False,
+    },
+    {
+        '.id': '*2',
+        'interface': 'bridge-no',
+        'advertise-dns': 'no',
+        'disabled': False,
+    },
+    {
+        '.id': '*3',
+        'interface': 'bridge-self',
+        'advertise-dns': 'self',
+        'disabled': False,
+    },
+]
+
+START_IPV6_ND_OLD_DATA = massage_expected_result_data(START_IPV6_ND, ('ipv6', 'nd'))
+
 START_IP_DHCP_CLIENT = [
     {
         "!comment": None,
@@ -590,6 +613,36 @@ class TestRouterosApiModifyModule(ModuleTestCase):
         self.assertEqual(result['changed'], False)
         self.assertEqual(result['old_data'], START_IP_DNS_STATIC_OLD_DATA)
         self.assertEqual(result['new_data'], START_IP_DNS_STATIC_OLD_DATA)
+
+    @patch('ansible_collections.community.routeros.plugins.modules.api_modify.compose_api_path',
+           new=create_fake_path(('ipv6', 'nd'), START_IPV6_ND, read_only=True))
+    def test_ipv6_nd_advertise_dns_enum_values_idempotent(self):
+        with self.assertRaises(AnsibleExitJson) as exc:
+            args = self.config_module_args.copy()
+            args.update({
+                'path': 'ipv6 nd',
+                'data': [
+                    {
+                        'interface': 'bridge-yes',
+                        'advertise-dns': 'yes',
+                    },
+                    {
+                        'interface': 'bridge-no',
+                        'advertise-dns': 'no',
+                    },
+                    {
+                        'interface': 'bridge-self',
+                        'advertise-dns': 'self',
+                    },
+                ],
+            })
+            with set_module_args(args):
+                self.module.main()
+
+        result = exc.exception.args[0]
+        self.assertEqual(result['changed'], False)
+        self.assertEqual(result['old_data'], START_IPV6_ND_OLD_DATA)
+        self.assertEqual(result['new_data'], START_IPV6_ND_OLD_DATA)
 
     @patch('ansible_collections.community.routeros.plugins.modules.api_modify.compose_api_path',
            new=create_fake_path(('ip', 'dns', 'static'), START_IP_DNS_STATIC))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
RouterOS 7.21 added "self" as a valid value for the IPv6 ND advertise-dns setting. Model advertise-dns as a string enum on RouterOS 7.21 and later while preserving the previous boolean default for older versions.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Add tests for the version boundary and idempotence with yes, no, and self values.
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
