### PR TITLE
Add RouterOS 7.23 bridge DHCP snooping options

### DIFF
--- a/changelogs/fragments/routeros-7.23-bridge-dhcp-snooping-options.yml
+++ b/changelogs/fragments/routeros-7.23-bridge-dhcp-snooping-options.yml
@@ -1,0 +1,10 @@
+minor_changes:
+  - api_info, api_modify - add support for the ``dhcp-agent-circuit-id``,
+    ``dhcp-agent-remote-id``, ``dhcpv6-agent-circuit-id``,
+    ``dhcpv6-agent-remote-id``, and ``dhcpv6-snooping`` parameters in the
+    ``interface bridge`` path for RouterOS >= 7.23.
+  - api_info, api_modify - add support for the ``trusted-dhcpv6`` parameter in
+    the ``interface bridge port`` path for RouterOS >= 7.23.
+  - api_info, api_modify - remove support for the deprecated
+    ``add-dhcp-option82`` parameter in the ``interface bridge`` path for
+    RouterOS >= 7.23.

--- a/changelogs/fragments/routeros-7.23-bridge-dhcp-snooping-options.yml
+++ b/changelogs/fragments/routeros-7.23-bridge-dhcp-snooping-options.yml
@@ -2,9 +2,9 @@ minor_changes:
   - api_info, api_modify - add support for the ``dhcp-agent-circuit-id``,
     ``dhcp-agent-remote-id``, ``dhcpv6-agent-circuit-id``,
     ``dhcpv6-agent-remote-id``, and ``dhcpv6-snooping`` parameters in the
-    ``interface bridge`` path for RouterOS >= 7.23.
+    ``interface bridge`` path for RouterOS >= 7.23 (https://github.com/ansible-collections/community.routeros/pull/468).
   - api_info, api_modify - add support for the ``trusted-dhcpv6`` parameter in
-    the ``interface bridge port`` path for RouterOS >= 7.23.
+    the ``interface bridge port`` path for RouterOS >= 7.23 (https://github.com/ansible-collections/community.routeros/pull/468).
   - api_info, api_modify - remove support for the deprecated
     ``add-dhcp-option82`` parameter in the ``interface bridge`` path for
-    RouterOS >= 7.23.
+    RouterOS >= 7.23 (https://github.com/ansible-collections/community.routeros/pull/468).

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -1779,8 +1779,13 @@ PATHS = {
             fully_understood=True,
             primary_keys=('name',),
             versioned_fields=[
-                ([('7.20', '>=')], 'add-dhcp-option82', KeyInfo(default=False)),
+                ([('7.20', '>='), ('7.23', '<')], 'add-dhcp-option82', KeyInfo(default=False)),
                 # ([('7.15', '>=')], 'copy-from', KeyInfo(write_only=True)),
+                ([('7.23', '>=')], 'dhcp-agent-circuit-id', KeyInfo(can_disable=True)),
+                ([('7.23', '>=')], 'dhcp-agent-remote-id', KeyInfo(can_disable=True)),
+                ([('7.23', '>=')], 'dhcpv6-agent-circuit-id', KeyInfo(can_disable=True)),
+                ([('7.23', '>=')], 'dhcpv6-agent-remote-id', KeyInfo(can_disable=True)),
+                ([('7.23', '>=')], 'dhcpv6-snooping', KeyInfo(default=False)),
                 ([('7.16', '>=')], 'forward-reserved-addresses', KeyInfo(default=False)),
                 ([('7.20', '>=')], 'igmp-version', KeyInfo(default=2)),
                 ([('7.0', '<')], 'ingress-filtering', KeyInfo(default=False)),
@@ -2138,6 +2143,7 @@ PATHS = {
                 ([('7.13', '<')], 'path-cost', KeyInfo(default=10)),
                 ([('7.13', '>=')], 'path-cost', KeyInfo(can_disable=True)),
                 # ([('7.15', '>=')], 'place-before', KeyInfo(write_only=True)),
+                ([('7.23', '>=')], 'trusted-dhcpv6', KeyInfo(default=False)),
                 ([('7.22', '>=')], 'trusted-ra', KeyInfo()),
             ],
             fields={


### PR DESCRIPTION

- add RouterOS >= 7.23 bridge fields for custom DHCP Option 82 and DHCPv6 snooping options
- add RouterOS >= 7.23 bridge port support for trusted-dhcpv6
- gate deprecated add-dhcp-option82 to RouterOS >= 7.20 and < 7.23
