### PR TITLE
Add RouterOS 7.23 IPv6 from-pool policy field

### DIFF
--- a/changelogs/fragments/routeros-7.23-ipv6-address-from-pool-policy.yml
+++ b/changelogs/fragments/routeros-7.23-ipv6-address-from-pool-policy.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - api_info, api_modify - add the ``from-pool-policy`` field to the ``ipv6 address`` path for RouterOS 7.23 and newer.

--- a/changelogs/fragments/routeros-7.23-ipv6-address-from-pool-policy.yml
+++ b/changelogs/fragments/routeros-7.23-ipv6-address-from-pool-policy.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - api_info, api_modify - add the ``from-pool-policy`` field to the ``ipv6 address`` path for RouterOS 7.23 and newer.
+  - api_info, api_modify - add the ``from-pool-policy`` field to the ``ipv6 address`` path for RouterOS 7.23 and newer (https://github.com/ansible-collections/community.routeros/pull/469).

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -8867,6 +8867,7 @@ PATHS = {
             versioned_fields=[
                 ([('7.18', '>=')], 'auto-link-local', KeyInfo()),
                 # ([('7.15', '>=')], 'copy-from', KeyInfo(write_only=True)),
+                ([('7.23', '>=')], 'from-pool-policy', KeyInfo(default='recommended')),
                 ([('7.15', '>=')], 'numbers', KeyInfo(read_only=True)),
             ],
             fields={


### PR DESCRIPTION
RouterOS 7.23 added `from-pool-policy` for IPv6 addresses to control how an address is acquired from an IPv6 pool. MikroTik documents `without-acquire` as one of the values of this field, so only `from-pool-policy` is added as collection metadata.
