### PR TITLE
`address` in `ip service` path is renamed to `available-from` in RouterOS 7.24

### DIFF
--- a/changelogs/fragments/ip-service-available-from.yml
+++ b/changelogs/fragments/ip-service-available-from.yml
@@ -1,3 +1,3 @@
 minor_changes:
-  - api_info, api_modify - the ``address`` parameter in the ``ip service`` path was renamed to ``available-from`` for RouterOS >= 7.24. The old name is still supported for RouterOS < 7.24.
-    (https://github.com/ansible-collections/community.routeros/pull/475)
+  - api_info, api_modify - the ``address`` parameter in the ``ip service`` path was renamed to ``available-from`` for RouterOS >= 7.24. The old name is still supported for RouterOS < 7.24
+    (https://github.com/ansible-collections/community.routeros/pull/475).

--- a/changelogs/fragments/ip-service-available-from.yml
+++ b/changelogs/fragments/ip-service-available-from.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - api_info, api_modify - the ``address`` parameter in the ``ip service`` path was renamed to ``available-from`` for RouterOS >= 7.24. The old name is still supported for RouterOS < 7.24.
+    (https://github.com/ansible-collections/community.routeros/pull/475)

--- a/plugins/module_utils/_api_data.py
+++ b/plugins/module_utils/_api_data.py
@@ -8466,9 +8466,10 @@ PATHS = {
                 ([('7.16', '>=')], 'max-sessions', KeyInfo(default=20)),
                 ([('7.15', '>=')], 'numbers', KeyInfo()),
                 ([('7.15', '>=')], 'vrf', KeyInfo()),
+                ([('7.24', '<')], 'address', KeyInfo()),
+                ([('7.24', '>=')], 'available-from', KeyInfo()),
             ],
             fields={
-                'address': KeyInfo(),
                 'certificate': KeyInfo(),
                 'disabled': KeyInfo(default=False),
                 'name': KeyInfo(),


### PR DESCRIPTION

##### SUMMARY

api_info, api_modify - the address parameter in the ip service path was renamed to available-from for RouterOS >= 7.24. The old name is still supported for RouterOS < 7.24.

##### COMPONENT NAME

`/ip/service` path.


##### ADDITIONAL INFORMATION

I don't known if it is possible to support both `address` and `available-from` on RouterOS >= 7.24. If yes, feel free to improve this MR.